### PR TITLE
Serve Assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 `shopify-cli-extensions` is an add-on to the Shopify CLI. Today, its main purpose is to power the experience of `shopify extension serve`, `shopify extension build` and augment `shopify extension create`. However, we will consider expanding its responsibilities in future.
 
+## Getting started
+
+To run the tests, simply execute the following shell command:
+
+```sh
+make test
+```
+
+To run the server, simply execute the following shell command:
+
+```sh
+make run
+```
+
 ## Technical Design
 
 - _Vault Project_: https://vault.shopify.io/projects/20476

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,2 +1,5 @@
 test:
 	go test ./...
+
+run:
+	go run . api/testdata/build

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -8,18 +8,26 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/gorilla/mux"
 )
 
 type api struct {
 	manifest *Manifest
-	*http.ServeMux
+	*mux.Router
 }
 
 func NewApi(manifest *Manifest) *api {
-	mux := http.NewServeMux()
+	mux := mux.NewRouter()
 	api := &api{manifest, mux}
 
-	mux.HandleFunc("/manifest", http.HandlerFunc(api.GenerateManifest))
+	mux.HandleFunc("/manifest", api.GenerateManifest)
+	mux.PathPrefix("/assets/").Handler(
+		http.StripPrefix(
+			"/assets/",
+			http.FileServer(http.Dir(manifest.Development.BuildDir)),
+		),
+	)
 
 	return api
 }

--- a/server/api/api_test.go
+++ b/server/api/api_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 )
 
+const (
+	buildDir = "testdata/build"
+)
+
 func TestGenerateManifest(t *testing.T) {
 	req, err := http.NewRequest("GET", "/manifest", nil)
 	if err != nil {
@@ -14,7 +18,7 @@ func TestGenerateManifest(t *testing.T) {
 	}
 	rec := httptest.NewRecorder()
 
-	api := NewApi(NewManifest())
+	api := NewApi(NewManifest(buildDir))
 	api.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -38,5 +42,21 @@ func TestGenerateManifest(t *testing.T) {
 
 	if manifest.User.Metafields == nil {
 		t.Error("Expected user metafields to not be null")
+	}
+}
+
+func TestServeAssets(t *testing.T) {
+	req, err := http.NewRequest("GET", "/assets/index.js", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+
+	api := NewApi(NewManifest(buildDir))
+	api.ServeHTTP(rec, req)
+
+	if rec.Body.String() != "console.log(\"Hello World!\");\n" {
+		t.Error("Unexpected body")
+		t.Log(rec.Body)
 	}
 }

--- a/server/api/manifest.go
+++ b/server/api/manifest.go
@@ -1,10 +1,13 @@
 package api
 
-func NewManifest() *Manifest {
+func NewManifest(buildDir string) *Manifest {
 	return &Manifest{
 		Assets: make([]Asset, 0),
 		User: User{
 			Metafields: make([]Metafield, 0),
+		},
+		Development: Development{
+			BuildDir: buildDir,
 		},
 		App: make(App),
 	}
@@ -33,6 +36,7 @@ type Development struct {
 	Renderer Renderer `json:"renderer"`
 	Hidden   bool     `json:"hidden"`
 	Focused  bool     `json:"focused"`
+	BuildDir string   `json:"-"`
 }
 
 type Renderer struct {

--- a/server/api/testdata/build/index.js
+++ b/server/api/testdata/build/index.js
@@ -1,0 +1,1 @@
+console.log("Hello World!");

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,3 +1,5 @@
 module github.com/Shopify/shopify-cli-extensions/server
 
 go 1.16
+
+require github.com/gorilla/mux v1.8.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/server/main.go
+++ b/server/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/Shopify/shopify-cli-extensions/server/api"
 )
 
 func main() {
-	api := api.NewApi(api.NewManifest())
+	api := api.NewApi(api.NewManifest(os.Args[1]))
 
 	mux := http.NewServeMux()
 	mux.Handle("/extensions/", http.StripPrefix("/extensions", api))

--- a/server/testdata/build/index.js
+++ b/server/testdata/build/index.js
@@ -1,0 +1,1 @@
+console.log("Hello World!");


### PR DESCRIPTION
* Switch standard router for Gorilla Mux
* make run task
* /extensions/assets now serves the directory passed as the first command line argument to the server
* Manifest.Development now holds the build directory
* Added some testdata

Co-authored-by: Cecy Correa <cecyc@users.noreply.github.com>
