### PR TITLE
GET /extensions/{uuid}/assets/*

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -7,6 +7,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/Shopify/shopify-cli-extensions/core"
@@ -22,12 +23,16 @@ func NewApi(service *core.ExtensionService) *api {
 	api := &api{service, mux.NewRouter()}
 
 	api.HandleFunc("/", api.extensionsHandler)
-	api.PathPrefix("/assets/").Handler(
-		http.StripPrefix(
-			"/assets/",
-			http.FileServer(http.Dir(service.Extensions[0].Development.BuildDir)),
-		),
-	)
+	for _, extension := range api.Extensions {
+		prefix := fmt.Sprintf("/%s/assets/", extension.UUID)
+
+		api.PathPrefix(prefix).Handler(
+			http.StripPrefix(
+				prefix,
+				http.FileServer(http.Dir(extension.Development.BuildDir)),
+			),
+		)
+	}
 
 	return api
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -55,7 +55,7 @@ func TestGetExtensions(t *testing.T) {
 }
 
 func TestServeAssets(t *testing.T) {
-	req, err := http.NewRequest("GET", "/assets/index.js", nil)
+	req, err := http.NewRequest("GET", "/00000000-0000-0000-0000-000000000000/assets/index.js", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -4,7 +4,10 @@ func NewExtensionService(buildDir string) *ExtensionService {
 	service := ExtensionService{
 		Version: "0.1.0",
 		Extensions: []Extension{{
-			Assets: make([]Asset, 0),
+			UUID: "00000000-0000-0000-0000-000000000000",
+			Assets: []Asset{
+				AssetFromUrl("http://localhost:8000/extensions/00000000-0000-0000-0000-000000000000/assets/index.js"),
+			},
 			User: User{
 				Metafields: make([]Metafield, 0),
 			},
@@ -31,6 +34,10 @@ type Extension struct {
 	User        User        `json:"user"`
 	App         App         `json:"app"`
 	Version     string      `json:"version"`
+}
+
+func AssetFromUrl(url string) Asset {
+	return Asset{Url{Url: url}}
 }
 
 type Asset struct {


### PR DESCRIPTION
Removes the previous /extensions/assets endpoint in favor of an endpoint
that supports multiple extensions. The new URL schema is as follows:

```
GET /extensions/{uuid}/assets/index.js
```

The Extension information is currently hard coded in
`NewExtensionService`. I will work on passing in actual configuration
data next.
