### PR TITLE
integrate Build command on main

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 
 	"github.com/Shopify/shopify-cli-extensions/api"
+	"github.com/Shopify/shopify-cli-extensions/build"
 	"github.com/Shopify/shopify-cli-extensions/core"
 )
 
@@ -33,7 +36,17 @@ type CLI struct {
 }
 
 func (cli *CLI) build(args ...string) {
-	panic("not implemented")
+	for _, e := range cli.config.Extensions {
+		b := build.NewBuilder(e.Development.BuildDir)
+
+		log.Printf("Building %s, id: %s", e.Type, e.UUID)
+
+		if err := b.Build(context.TODO()); err != nil {
+			log.Printf("Extension %s failed to build. Error: %s", e.UUID, err)
+		} else {
+			log.Printf("Extension %s built successfully!", e.UUID)
+		}
+	}
 }
 
 func (cli *CLI) create(args ...string) {


### PR DESCRIPTION
* integrates `build.Build()` into main, reads data from config

To do:

* [x] ensure build can handle multiple extensions
* [ ] integrate `Develop()` command -- separate PR?

🎩 Tophat:

In `testdata/shopifile.yml`, change `build_dir` to `build/testdata/checkout-ui-extension`.

You should see the following output:

```sh
make run build < testdata/shopifile.yml
Makefile:9: warning: overriding commands for target `build'
Makefile:4: warning: ignoring old commands for target `build'
go run . build
2021/08/26 14:08:34 Building checkout_ui_extension, id: 00000000-0000-0000-0000-000000000000
2021/08/26 14:08:34 Extension 00000000-0000-0000-0000-000000000000 built successfully!
2021/08/26 14:08:34 Building checkout_ui_extension, id: 00000000-0000-0000-0000-000000000001
2021/08/26 14:08:34 Extension 00000000-0000-0000-0000-000000000001 built successfully!
go build -o shopify-extensions .
```
To test that if one errors out, the other builds will carry on, you can change the `build_dir` of the first extension back to `api/testdata/shopifile.yml`. 

You should see the first extension's build will error out, but the process will continue and the second extension will build:

```sh
❯ make run build < testdata/shopifile.yml
Makefile:9: warning: overriding commands for target `build'
Makefile:4: warning: ignoring old commands for target `build'
go run . build
2021/08/26 14:50:05 Building checkout_ui_extension, id: 00000000-0000-0000-0000-000000000000
2021/08/26 14:50:06 Extension 00000000-0000-0000-0000-000000000000 failed to build. Error: Build process failed: exit status 1
2021/08/26 14:50:06 Building checkout_ui_extension, id: 00000000-0000-0000-0000-000000000001
2021/08/26 14:50:06 Extension 00000000-0000-0000-0000-000000000001 built successfully!
go build -o shopify-extensions .
```