### PR TITLE
create global context, improve error handling in build > RunScript

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os/exec"
 
@@ -20,50 +19,51 @@ type Builder struct {
 
 type Result struct {
 	Success bool
+	Error   error
 }
 
 // production build
-func (b *Builder) Build(ctx context.Context) error {
+func (b *Builder) Build(ctx context.Context) Result {
 	_, err := b.RunScript(ctx, "build")
 
 	if err != nil {
-		return fmt.Errorf("Build process failed: %v", err)
+		return Result{false, err}
 	}
 
-	return nil
+	return Result{true, nil}
 }
 
 // development build
-func (b *Builder) Develop(ctx context.Context, dir string, yield func(result Result)) error {
+func (b *Builder) Develop(ctx context.Context, dir string, yield func(result Result)) Result {
 	_, err := b.RunScript(ctx, "develop")
 
 	if err != nil {
-		return fmt.Errorf("Develop process failed: %v", err)
+		return Result{false, err}
 	}
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return fmt.Errorf("Failed to start watcher process: %v", err)
+		return Result{false, err}
 	}
 	defer watcher.Close()
 
 	if err = watcher.Add(dir); err != nil {
-		return fmt.Errorf("Failed to watch directory %v, error: %v", dir, err)
+		return Result{false, err}
 	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			log.Println("Terminating watcher")
-			return nil
+			return Result{true, nil}
 		case event := <-watcher.Events:
 			if event.Op&fsnotify.Write == fsnotify.Write {
 				log.Printf("file system event: %v\n", event)
-				yield(Result{true})
+				yield(Result{true, nil})
 			}
 		case err = <-watcher.Errors:
 			log.Printf("file system error: %v\n", err)
-			yield(Result{false})
+			yield(Result{false, nil})
 		}
 	}
 }

--- a/build/build_test.go
+++ b/build/build_test.go
@@ -19,10 +19,14 @@ func TestBuild(t *testing.T) {
 	}
 
 	builder := Builder{ScriptRunnerFunc(fakeRunner)}
-	err := builder.Build(context.TODO())
+	result := builder.Build(context.TODO())
 
-	if err != nil {
-		t.Errorf("Expected error to be nil, got %s", err)
+	if !result.Success {
+		t.Error("Expected Build operation to be successful")
+	}
+
+	if result.Error != nil {
+		t.Errorf("Expected error to be nil, got %s", result.Error)
 	}
 
 	if !runnerWasCalled {
@@ -36,10 +40,14 @@ func TestBuildErrors(t *testing.T) {
 	}
 
 	builder := Builder{ScriptRunnerFunc(fakeRunner)}
-	err := builder.Build(context.TODO())
+	result := builder.Build(context.TODO())
 
-	if err == nil {
-		t.Errorf("Unexpected error %v", err)
+	if result.Success {
+		t.Error("Expected Build operation to fail with errors")
+	}
+
+	if result.Error == nil {
+		t.Errorf("Expected error to not be nil")
 	}
 }
 
@@ -57,9 +65,13 @@ func TestDevelop(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), d)
 	defer cancel()
 
-	err := builder.Develop(ctx, "testdata", func(result Result) {})
+	result := builder.Develop(ctx, "testdata", func(result Result) {})
 
-	if err != nil {
-		t.Errorf("Unexpected error %v", err)
+	if !result.Success {
+		t.Error("Expected Develop to be successful")
+	}
+
+	if result.Error != nil {
+		t.Errorf("Unexpected error %v", result.Error)
 	}
 }

--- a/build/package_manager_test.go
+++ b/build/package_manager_test.go
@@ -3,8 +3,8 @@ package build
 import (
 	"context"
 	"errors"
-	"log"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -63,9 +63,27 @@ func TestRunScript(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	log.Printf("***STDOUT %s", stdout)
-
 	if stdout != "Hello world!\n" {
 		t.Errorf("Unexpected output from test file: %v", stdout)
+	}
+}
+
+func TestRunScriptErrorIfDirectoryNotFound(t *testing.T) {
+	pm := &PackageManager{
+		name: "bash",
+		formatArgs: func(script string, args ...string) []string {
+			return []string{script}
+		},
+		workingDir: "doesnotexist123",
+	}
+
+	_, err := pm.RunScript(context.TODO(), "test.sh")
+
+	if err == nil {
+		t.Error("Expected operation to be unsuccessful")
+	}
+
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Errorf("Expected error to include 'no such file or directory', got: %v", err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -12,6 +12,12 @@ import (
 	"github.com/Shopify/shopify-cli-extensions/core"
 )
 
+var ctx context.Context
+
+func init() {
+	ctx = context.Background()
+}
+
 func main() {
 	config, err := core.LoadConfig(os.Stdin)
 	if err != nil {
@@ -36,16 +42,30 @@ type CLI struct {
 }
 
 func (cli *CLI) build(args ...string) {
+	build_errors := 0
+
 	for _, e := range cli.config.Extensions {
 		b := build.NewBuilder(e.Development.BuildDir)
 
 		log.Printf("Building %s, id: %s", e.Type, e.UUID)
 
-		if err := b.Build(context.TODO()); err != nil {
-			log.Printf("Extension %s failed to build. Error: %s", e.UUID, err)
-		} else {
+		result := b.Build(ctx)
+
+		if result.Success {
 			log.Printf("Extension %s built successfully!", e.UUID)
+		} else {
+			build_errors += 1
+			log.Printf("Extension %s failed to build: %s", e.UUID, result.Error.Error())
 		}
+	}
+
+	switch {
+	case build_errors == 1:
+		log.Println("There was an error during build, please check your logs for more information.")
+		os.Exit(1)
+	case build_errors > 1:
+		log.Printf("There were %d errors during build, please check your logs for more information.", build_errors)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Part of https://github.com/Shopify/shopify-cli-extensions/issues/2

* Add global context to main `init()` function
* Include `error` in Result
* Capture `stderr` from `build.build()` process and return it
* Write build errors from `main.Cli.build()` to stderr

### Before:

```sh
❯ make run build < testdata/shopifile.yml
go run . build
2021/08/26 14:50:05 Building checkout_ui_extension, id: 00000000-0000-0000-0000-000000000000
2021/08/26 14:50:06 Extension 00000000-0000-0000-0000-000000000000 failed to build. Error: Build process failed: exit status 1
```

### After:

```sh
❯ make run build < testdata/shopifile.yml
go run . build
2021/08/27 11:54:45 Building checkout_ui_extension, id: 00000000-0000-0000-0000-000000000000
2021/08/27 11:54:45 Extension 00000000-0000-0000-0000-000000000000 failed to build. error Couldn't find a package.json file in "/Users/cecycorrea/src/github.com/Shopify/shopify-cli-extensions/api/testdata/build"
2021/08/30 11:41:11 There was an error during build, please check your logs for more information.
exit status 1
make: *** [run] Error 1
```

You can see we are returning better error messaging.

**If directory does not exist:**

```sh
❯ make run build < testdata/shopifile.yml
go run . build
2021/08/27 12:22:02 Building checkout_ui_extension, id: 00000000-0000-0000-0000-000000000000
2021/08/27 12:22:02 Extension 00000000-0000-0000-0000-000000000000 failed to build: stat api/testdata/builds/: no such file or directory
```

### 🎩 Tophatting:

Change your shopifile to the following to test different scenarios.

#### Test 2 successful builds

```
extensions:
  - uuid: 00000000-0000-0000-0000-000000000000
    type: checkout_ui_extension
    user:
      metafields: []
    development:
      build_dir: "build/testdata/checkout-ui-extension/"
  - uuid: 00000000-0000-0000-0000-000000000001
    type: checkout_ui_extension
    user:
      metafields: []
    development:
      build_dir: "build/testdata/checkout-ui-extension/"
```

#### Test one successful build and one failure

```
extensions:
  - uuid: 00000000-0000-0000-0000-000000000000
    type: checkout_ui_extension
    user:
      metafields: []
    development:
      build_dir: "build/testdata/checkout-ui-extension/"
  - uuid: 00000000-0000-0000-0000-000000000001
    type: checkout_ui_extension
    user:
      metafields: []
    development:
      build_dir: "api/testdata/build/"
```

#### Test a non-existent directory

```
extensions:
  - uuid: 00000000-0000-0000-0000-000000000000
    type: checkout_ui_extension
    user:
      metafields: []
    development:
      build_dir: "build/testdata/checkout-ui-extensions/"
```

