### PR TITLE
Version and persisted config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,10 @@ endif
 
 .PHONY: build
 build:
-	@echo Building executable
 	go build -o ${executable}
 
 .PHONY: package
-package: build
+package:
 ifeq ($(GOOS),)
 	@echo Requires GOOS to be set >&2
 	exit 1
@@ -26,8 +25,13 @@ ifeq ($(GOARCH),)
 	@echo Requires GOARCH to be set >&2
 	exit 1
 endif
+	@echo Run code generation
+	go generate
 
-	@echo Packaging executable
+	@echo Build executable
+	go build -o ${executable}
+
+	@echo Package executable
 	tar czf shopify-extensions-$(GOOS)-$(GOARCH).tar.gz ${executable}
 
 .PHONY: test

--- a/main.go
+++ b/main.go
@@ -17,7 +17,8 @@ import (
 
 var ctx context.Context
 
-const version = "0.1.0"
+//go:generate sh -c "git tag -l | sort | tail -n 1 | xargs -I {} sed -r -i '' 's/^const version = .*$/const version = \"{}\"/' main.go"
+const version = "v0.0.0"
 
 func init() {
 	ctx = context.Background()


### PR DESCRIPTION
* Adds support for `shopify-extensions version`
* Adds support for reading configuration files from disk. `build`, `serve` and `create` now expect a second command line argument that it is either a path to a file or `-` for standard in to indicate where the configuration data is sourced from.
* Adds support for automatically updating the version during `make package` from the latest git tag.

I did a 🎩  by creating a new `v0.1.0` release. I downloaded the mac version and then ran `shopify-extension version` which indeed produced `v0.1.0`.