### PR TITLE
Use GZip only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,12 @@ name: Release
 on:
   release:
     types: [created, edited]
+  pull_request:
+    branches: [main]
 
 jobs:
   releases-matrix:
-    name: Release shopify-extensions
+    name: ${{ github.event_name == 'release' && 'Release' || 'Test packaging of' }} shopify-extensions
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,7 +29,13 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
+      - name: Setup ruby
+        uses: actions/setup-ruby@v1
       - name: Build and package executable
-        run: GOOS=${{ matrix.goos}} GOARCH=${{ matrix.goarch }} make package
+        run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} make package
       - name: Release
-        run: echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token && gh release upload `basename ${{ github.ref }}` shopify-extensions-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token && \
+          gh release upload `basename ${{ github.ref }}` shopify-extensions-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }}.gz && \
+          gh release upload `basename ${{ github.ref }}` shopify-extensions-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }}.md5

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,16 +17,6 @@ jobs:
       - name: Test
         run: make test
 
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
-      - name: Build
-        run: make build
-
   integration-test:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ endif
 
 ifeq ($(GOOS),windows)
 	executable := shopify-extensions.exe
+	canonical_name := shopify-extensions-$(GOOS)-$(GOARCH).exe
 else
 	executable := shopify-extensions
+	canonical_name := shopify-extensions-$(GOOS)-$(GOARCH)
 endif
 
 .PHONY: build
@@ -32,7 +34,8 @@ endif
 	go build -o ${executable}
 
 	@echo Package executable
-	tar czf shopify-extensions-$(GOOS)-$(GOARCH).tar.gz ${executable}
+	md5sum ${executable} > ${canonical_name}.md5
+	gzip ${executable} && mv ${executable}.gz ${canonical_name}.gz
 
 .PHONY: test
 test:
@@ -72,3 +75,6 @@ integration-test:
 		../../shopify-extensions build -
 	test -f tmp/integration_test/build/main.js
 
+.PHONY: update-version
+update-version:
+	git tag -l | sort | tail -n 1 | xargs -I {} ruby -i -pe 'sub(/^const version = .*$$/, "const version = \"{}\"")' -- main.go

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 
 var ctx context.Context
 
-//go:generate sh -c "git tag -l | sort | tail -n 1 | xargs -I {} sed -r -i '' 's/^const version = .*$/const version = \"{}\"/' main.go"
+//go:generate make update-version
 const version = "v0.0.0"
 
 func init() {


### PR DESCRIPTION
This PR tweaks our release workflow

* Stop wrapping the binaries in tarballs – it's unnecessary because we're compressing a single file and possibly related to the Windows issue I'm investigating
* Produce md5 sum files for verification purposes
* Change version update mechanism from using `sed` to using `ruby`
* Run packaging tests on every PR to ensure that our release workflow isn't broken

<img width="1238" alt="Screen Shot 2021-09-13 at 5 04 08 PM" src="https://user-images.githubusercontent.com/77060/133156201-eb1ca583-f266-4923-851b-31c338def56d.png">
