### PR TITLE
Websocket shutdown

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -104,11 +104,12 @@ func (api *ExtensionsApi) sendStatusUpdates(rw http.ResponseWriter, r *http.Requ
 	ws.WriteJSON(StatusUpdate{Type: "connected", Extensions: api.Extensions})
 
 	go func() {
-		defer ws.Close()
+		// TODO: Handle messages from the client
+		// Currently we don't do anything with the messages
+		// but the code is needed to establish a two-way connection
 		for {
 			_, _, err := ws.ReadMessage()
 			if err != nil {
-				log.Println("client connection closed")
 				break
 			}
 		}
@@ -120,13 +121,10 @@ func (api *ExtensionsApi) sendStatusUpdates(rw http.ResponseWriter, r *http.Requ
 
 		ws.SetWriteDeadline(time.Now().Add(1 * time.Second))
 		err := ws.WriteJSON(&notification)
-		log.Println("Writing update message")
 		if err != nil {
 			break
 		}
 	}
-
-	log.Println("Socket closed")
 }
 
 func (api *ExtensionsApi) listExtensions(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fix https://github.com/Shopify/shopify-cli-extensions/issues/70

### Tophat

Run `make bootstrap; make build` to set up

**Client close connection**
1. Run `./shopify-extensions serve < testdata/shopifile.yml`
2. In a web browser, open a console and paste the following code
```js
var ws = new WebSocket("ws://localhost:8000/extensions/");
ws.onClose = console.log;
ws.close(1000, "done");
```
3. Verify that the console logs out a close event with the code `1000`, the reason set to `"done"` and `wasClean = true`
![image](https://user-images.githubusercontent.com/29458473/133553260-c6516f2b-3dc8-4d0c-accb-6d6c612b9aab.png)

**Server shut down**
1. Run `./shopify-extensions serve < testdata/shopifile.yml`
2. In a web browser, open a console and paste the following code
```js
var ws = new WebSocket("ws://localhost:8000/extensions/");
ws.onClose = console.log;
```
3. In the terminal running serve, kill the process. Note that there's a `panic: send on closed channel` thrown but this is not related to the websocket shutting down. We are currently not handling interrupts in the code to [`monitor`](https://github.com/Shopify/shopify-cli-extensions/blob/2e7c5f9d04d0fda1e9e01f20f10af63d81a70deb/main.go#L140) so it tries to send a build error notification. This can be cleaned up in a later PR.
4. Verify that the console logs out a close event with the code `1000`, the reason set to `"server shut down"` and `wasClean = true`
![image](https://user-images.githubusercontent.com/29458473/133553504-f4591481-1312-45ab-9b23-212770e4253f.png)
