### PR TITLE
Fix extension urls and merging update data

### DIFF
--- a/api/testdata/shopifile.yml
+++ b/api/testdata/shopifile.yml
@@ -6,7 +6,9 @@ extensions:
   - uuid: 00000000-0000-0000-0000-000000000000
     type: checkout_ui_extension
     user:
-      metafields: []
+      metafields:
+        - namespace: my-namespace
+          key: my-key
     development:
       root_dir: "testdata"
       build_dir: "build"
@@ -15,7 +17,9 @@ extensions:
   - uuid: 00000000-0000-0000-0000-000000000001
     type: checkout_ui_extension
     user:
-      metafields: []
+      metafields:
+        - namespace: my-namespace
+          key: my-key
     development:
       root_dir: "testdata"
       build_dir: "build"

--- a/core/core.go
+++ b/core/core.go
@@ -7,8 +7,11 @@ import (
 )
 
 func NewExtensionService(config *Config, apiRoot string) *ExtensionService {
-	for index := range config.Extensions {
-		config.Extensions[index].Assets = make(map[string]Asset)
+	// Create a copy so we don't mutate the configs
+	extensions := []Extension{}
+	for _, extension := range config.Extensions {
+		extension.Assets = make(map[string]Asset)
+		extensions = append(extensions, extension)
 	}
 	// TODO: Improve this when we need to read more app configs,
 	// for now we only know and care about api_key
@@ -18,7 +21,7 @@ func NewExtensionService(config *Config, apiRoot string) *ExtensionService {
 	service := ExtensionService{
 		App:        app,
 		Version:    "0.1.0",
-		Extensions: config.Extensions,
+		Extensions: extensions,
 		Port:       config.Port,
 		Store:      config.Store,
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"io"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 )
@@ -75,7 +76,6 @@ type Development struct {
 	Resource Url               `json:"resource"`
 	Renderer Renderer          `json:"-" yaml:"renderer"`
 	Hidden   bool              `json:"hidden"`
-	Focused  bool              `json:"focused"`
 	BuildDir string            `json:"-" yaml:"build_dir"`
 	RootDir  string            `json:"-" yaml:"root_dir"`
 	Template string            `json:"-"`
@@ -101,4 +101,14 @@ type App map[string]interface{}
 
 type Url struct {
 	Url string `json:"url" yaml:"url"`
+}
+
+func (t Extension) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ.Kind() == reflect.Bool {
+		return func(dst, src reflect.Value) error {
+			dst.SetBool(src.Bool())
+			return nil
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Related to https://github.com/Shopify/shopify-cli-extensions/issues/95
- use a custom transformer with`mergo.Merge` to allow updating extension data after initial values are set and support setting booleans to `false`
- populate extension urls dynamically with every response

### Tophat
1. Run `make bootstrap` and then `make run serve testdata/shopifile.yml`
2. In another terminal, run `ngrok http 8000`
2. Open http://localhost:8000/extensions/ in the browser and open the Chrome console.
3. Connect to the websocket `var notSecure = new WebSocket("ws:localhost:8000/extensions/")`
4. Verify that you receive a "connected" payload with all extension urls starting with `http://localhost:8000`
![image](https://user-images.githubusercontent.com/29458473/135914157-9e9f3185-b48d-47e1-9882-027fffe4f97b.png)
5. Connect to the secure websocket, ex.`var secure = new WebSocket("wss:d7d8-45-3-5-121.ngrok.io/extensions/")`
6. Verify that you receive a "connected" payload with all extension urls starting with `https://YOUR-TUNNEL-URL`

7. Through the secure connection, send an update event 
```js
ws.send(JSON.stringify({event: "update", data: {extensions: [{uuid: "00000000-0000-0000-0000-000000000000", development: {hidden:true, status: "1st update"}}]}}));
```
8. Verify that the secure connection receives an update with all extension urls starting with `https://YOUR-TUNNEL-URL` and the extension is updated with `development.hidden = true` and `development.status = "1st update"`

9. Verify that the insecure connection receives an update with all extension urls starting with `http://localhost:8000` the extension is updated with `development.hidden = true` and `development.status = "1st update"`

7. Through the secure connection, send an update event 
```js
ws.send(JSON.stringify({event: "update", data: {extensions: [{uuid: "00000000-0000-0000-0000-000000000000", development: {hidden:false, status: "2nd update"}}]}}));
```
10. Verify that both connections receive an update event with the extension info set to `development.hidden = false` and `development.status = "2nd update"`