### PR TITLE
Handle HTML requests for individual extensions

### DIFF
--- a/api/root/root.go
+++ b/api/root/root.go
@@ -1,0 +1,180 @@
+package root
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/Shopify/shopify-cli-extensions/core"
+	"github.com/Shopify/shopify-cli-extensions/core/fsutils"
+)
+
+//go:embed templates/*
+var templates embed.FS
+
+func New(config *core.Config, apiRoot string) *RootHandler {
+	return &RootHandler{
+		fsutils.NewFS(&templates, "templates"),
+		&apiConfig{
+			ApiRoot: apiRoot,
+			Port:    config.Port,
+			Store:   config.Store,
+		},
+	}
+}
+
+func (root *RootHandler) HandleHTMLRequest(rw http.ResponseWriter, r *http.Request, extension *core.Extension) {
+	templateData := &extensionHtmlTemplateData{
+		extension,
+		root.apiConfig,
+		fmt.Sprintf("%s%s", root.ApiRoot, extension.UUID),
+	}
+
+	if !IsSecureRequest(r) {
+		content, err := root.getTunnelError(templateData)
+		if err != nil {
+			root.handleError(rw, fmt.Errorf("failed to render index page: %v", err))
+			return
+		}
+		rw.Write(content)
+		return
+	}
+
+	if getSurface(extension) == postPurchase {
+		content, err := root.getIndexContent(templateData)
+		if err != nil {
+			root.handleError(rw, fmt.Errorf("failed to render index page: %v", err))
+			return
+		}
+		rw.Write(content.Bytes())
+		return
+	}
+
+	url, err := root.getRedirectUrl(r, extension)
+	if err != nil {
+		root.handleError(rw, fmt.Errorf("failed to construct redirect url: %v", err))
+		return
+	}
+
+	http.Redirect(rw, r, url, http.StatusPermanentRedirect)
+}
+
+func IsSecureRequest(r *http.Request) bool {
+	// TODO: Find a better way to handle this - looks like there's no easy way to get the request protocol
+	re := regexp.MustCompile(`:([0-9])+$`)
+	hasPort := re.MatchString(r.Host)
+	return !strings.HasPrefix(r.Host, "localhost") && !hasPort
+
+}
+
+func (root *RootHandler) GetApiRootUrlFromRequest(r *http.Request) string {
+	var protocol string
+	if IsSecureRequest(r) {
+		protocol = "https"
+	} else {
+		protocol = "http"
+	}
+
+	return fmt.Sprintf("%s://%s%s", protocol, r.Host, root.ApiRoot)
+}
+
+func (root *RootHandler) getTunnelError(templateData *extensionHtmlTemplateData) (mergedContent []byte, err error) {
+	content, err := root.getTunnelErrorContent(templateData)
+
+	if err != nil {
+		return
+	}
+	mergedContent = content.Bytes()
+	return
+}
+
+func (root *RootHandler) getTunnelErrorContent(templateData *extensionHtmlTemplateData) (*bytes.Buffer, error) {
+	specificTemplatePath := filepath.Join(templateData.Type, "tunnel-error.html.tpl")
+	globalTemplatePath := filepath.Join("tunnel-error.html.tpl")
+
+	if !root.FileExists(specificTemplatePath) {
+		return root.MergeTemplateData(templateData, globalTemplatePath)
+	}
+	return root.MergeTemplateData(templateData, specificTemplatePath)
+}
+
+func (root *RootHandler) getIndexContent(templateData *extensionHtmlTemplateData) (*bytes.Buffer, error) {
+	specificTemplatePath := filepath.Join(templateData.Type, "index.html.tpl")
+	return root.MergeTemplateData(templateData, specificTemplatePath)
+}
+
+func (root *RootHandler) getRedirectUrl(r *http.Request, extension *core.Extension) (url string, err error) {
+	if root.Store == "" {
+		err = fmt.Errorf("store is not defined")
+		return
+	}
+
+	if getSurface(extension) == checkout {
+		if extension.Development.Resource.Url == "" {
+			err = fmt.Errorf("resource url is not defined")
+			return
+		}
+
+		url = fmt.Sprintf("https://%s/%s?dev=%s", root.Store, extension.Development.Resource.Url, root.GetApiRootUrlFromRequest(r))
+		return
+	}
+
+	url = fmt.Sprintf("https://%s/admin/extensions-dev?url=%s", root.Store, extension.Development.Root.Url)
+	return
+}
+
+func (root *RootHandler) getErrorContent(err error) (*bytes.Buffer, error) {
+	return root.MergeTemplateData(errorsTemplateData{err.Error()}, filepath.Join("error.html.tpl"))
+}
+
+func (root *RootHandler) handleError(rw http.ResponseWriter, errorMessage error) {
+	content, err := root.getErrorContent(errorMessage)
+	if err != nil {
+		rw.Write([]byte(fmt.Sprintf("cannot return error page: %v", err)))
+		return
+	}
+	rw.Write(content.Bytes())
+}
+
+func getSurface(extension *core.Extension) surface {
+	if strings.Contains(extension.Development.Renderer.Name, "checkout") {
+		return checkout
+	}
+	if strings.Contains(extension.Development.Renderer.Name, "post-purchase") {
+		return postPurchase
+	}
+	return admin
+}
+
+type apiConfig struct {
+	ApiRoot string
+	Port    int
+	Store   string
+}
+
+type RootHandler struct {
+	*fsutils.FS
+	*apiConfig
+}
+
+type extensionHtmlTemplateData struct {
+	*core.Extension
+	*apiConfig
+	RelativePath string
+}
+
+type errorsTemplateData struct {
+	Error string
+}
+
+type surface int64
+
+const (
+	admin surface = iota
+	checkout
+	postPurchase
+)

--- a/api/root/templates/checkout_post_purchase/index.html.tpl
+++ b/api/root/templates/checkout_post_purchase/index.html.tpl
@@ -1,0 +1,41 @@
+<html>
+  <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, height=device-height, viewport-fit=cover">
+  <style>
+      * {
+      box-sizing: border-box;
+      }
+      body {
+      min-height: 100vh;
+      min-height: -webkit-fill-available;
+      display: grid;
+      margin: 0;
+      align-content: center;
+      justify-content: center;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+          'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+          sans-serif;
+      }
+      html {
+      height: -webkit-fill-available;
+      background: black;
+      color: white;
+      }
+      .content {
+      max-width: 40rem;
+      padding: 2rem;
+      font-size: 1.5em;
+      }
+      code {
+      color: mediumseagreen;
+      word-break: keep-all;
+      }
+  </style>
+  </head>
+  <body>
+  <div class="content">
+      <p>This page is served by your local UI Extension development server. Instead of visiting this page directly, you will need to connect your local development environment to a real checkout environment.</p>
+      <p>Create a checkout and append <code>?dev={{ .Development.Root.Url }}</code> to the URL to start developing your extension.</p>
+  </div>
+  </body>
+</html>

--- a/api/root/templates/checkout_post_purchase/tunnel-error.html.tpl
+++ b/api/root/templates/checkout_post_purchase/tunnel-error.html.tpl
@@ -1,0 +1,41 @@
+<html>
+  <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, height=device-height, viewport-fit=cover">
+  <style>
+      * {
+      box-sizing: border-box;
+      }
+      body {
+      min-height: 100vh;
+      min-height: -webkit-fill-available;
+      display: grid;
+      margin: 0;
+      align-content: center;
+      justify-content: center;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+          'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+          sans-serif;
+      }
+      html {
+      height: -webkit-fill-available;
+      background: black;
+      color: white;
+      }
+      .content {
+      max-width: 40rem;
+      padding: 2rem;
+      font-size: 1.5em;
+      }
+      code {
+      color: mediumseagreen;
+      word-break: keep-all;
+      }
+  </style>
+  </head>
+  <body>
+  <div class="content">
+      <p>This page is served by your local UI Extension development server. Instead of visiting this page directly, you will need to connect your local development environment to a real checkout environment.</p>
+      <p>Make sure you have a secure URL for your local development server by running <code>shopify extension tunnel start --port={{ .Port }}</code>, create a checkout, and append <code>?dev=https://TUNNEL_URL{{ .ApiRoot }}</code> to the URL, where <code>TUNNEL_URL</code> is replaced with your own ngrok URL.</p>
+  </div>
+  </body>
+</html>

--- a/api/root/templates/error.html.tpl
+++ b/api/root/templates/error.html.tpl
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Error</title>
+	<meta charset="UTF-8" />
+</head>
+
+<body>
+	<div id="title">Error accessing the extension</div>
+    
+	<div id="description"> {{ .Error }}</div>
+	<style>
+		html {
+			height: 100%;
+			font-family: -apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
+			font-size: 100%;
+		}
+
+		body {
+			height: 100%;
+			text-align: center;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+		}
+
+		#title {
+			font-size: 1.5rem;
+			line-height: 1.75rem;
+			margin-bottom: 1rem;
+		}
+
+		#description {
+			font-size: 0.875rem;
+			line-height: 1.25rem;
+		}
+	</style>
+</body>
+
+</html>

--- a/api/root/templates/tunnel-error.html.tpl
+++ b/api/root/templates/tunnel-error.html.tpl
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Tunnel Error</title>
+	<meta charset="UTF-8" />
+</head>
+
+<body>
+	<div id="search-logo">
+		<svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path d="M6 24C6 14.073 14.073 6 24 6C33.927 6 42 14.073 42 24C42 33.927 33.927 42 24 42C14.073 42 6 33.927 6 24ZM59.121 54.879L42.936 38.691C46.2175 34.4971 48.0003 29.3252 48 24C48 10.767 37.233 0 24 0C10.767 0 0 10.767 0 24C0 37.233 10.767 48 24 48C29.3249 47.9984 34.4962 46.2159 38.691 42.936L54.879 59.121C55.157 59.4006 55.4874 59.6224 55.8514 59.7738C56.2154 59.9252 56.6058 60.0031 57 60.0031C57.3942 60.0031 57.7846 59.9252 58.1486 59.7738C58.5126 59.6224 58.843 59.4006 59.121 59.121C59.3998 58.8426 59.6211 58.512 59.772 58.1481C59.9229 57.7841 60.0006 57.394 60.0006 57C60.0006 56.606 59.9229 56.2159 59.772 55.8519C59.6211 55.488 59.3998 55.1574 59.121 54.879Z" fill="#83898F"/>
+		</svg>		
+	</div>
+
+	<div id="title">Tunnel not found</div>
+    
+	<div id="description">
+        <p>This page should redirect to a store with your local extension connected when a secure connection is established.</p>
+        <p>Make sure you have a secure URL for your local development server by running <code>shopify extension tunnel start --port={{ .Port }}</code> and then visit the url https://TUNNEL_URL{{ .RelativePath }}</code>, where <code>TUNNEL_URL</code> is replaced with your own ngrok URL.</p>
+    </div>
+	<style>
+		html {
+			height: 100%;
+			font-family: -apple-system,BlinkMacSystemFont,San Francisco,Segoe UI,Roboto,Helvetica Neue,sans-serif;
+			font-size: 100%;
+		}
+
+		body {
+			height: 100%;
+			text-align: center;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+		}
+
+		#search-logo {
+			margin-bottom: 2rem;
+		}
+
+		#title {
+			font-size: 1.5rem;
+			line-height: 1.75rem;
+			margin-bottom: 1rem;
+		}
+
+		#description {
+			font-size: 0.875rem;
+			line-height: 1.25rem;
+		}
+	
+	</style>
+</body>
+
+</html>

--- a/api/testdata/shopifile.yml
+++ b/api/testdata/shopifile.yml
@@ -1,5 +1,6 @@
 ---
 port: 8000
+store: test-shop.myshopify.com
 app:
   api_key: app_api_key
 extensions:
@@ -14,8 +15,21 @@ extensions:
       build_dir: "build"
       entries:
         main: "src/index.tsx"
+      resource:
+        url: "cart/1234"
+      renderer:
+        name: "@shopify/checkout-ui-extensions"
   - uuid: 00000000-0000-0000-0000-000000000001
-    type: checkout_ui_extension
+    type: product_subscription
+    development:
+      root_dir: "testdata"
+      build_dir: "build"
+      entries:
+        main: "src/index.tsx"
+      renderer:
+        name: "@shopify/admin-ui-extensions"
+  - uuid: 00000000-0000-0000-0000-000000000002
+    type: checkout_post_purchase
     user:
       metafields:
         - namespace: my-namespace
@@ -25,3 +39,5 @@ extensions:
       build_dir: "build"
       entries:
         main: "src/index.tsx"
+      renderer:
+        name: "@shopify/post-purchase-ui-extensions"

--- a/core/core.go
+++ b/core/core.go
@@ -55,6 +55,7 @@ type ExtensionService struct {
 	Port       int
 	Store      string
 	Version    string
+	PublicUrl  string
 }
 
 type Extension struct {

--- a/create/create.go
+++ b/create/create.go
@@ -1,16 +1,14 @@
 package create
 
 import (
-	"bytes"
 	"embed"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
-	"text/template"
 
 	"github.com/Shopify/shopify-cli-extensions/core"
-	"github.com/Shopify/shopify-cli-extensions/create/fsutils"
+	"github.com/Shopify/shopify-cli-extensions/core/fsutils"
 	"github.com/Shopify/shopify-cli-extensions/create/process"
 )
 
@@ -107,7 +105,7 @@ func MergeTemplates(fs *fsutils.FS, project *project) process.Task {
 
 					targetFilePath := strings.TrimSuffix(targetPath, templateFileExtension)
 
-					content, err := mergeTemplateWithData(project, filePath)
+					content, err := fs.MergeTemplateData(project, filePath)
 					if err != nil {
 						return
 					}
@@ -233,26 +231,6 @@ func mergeJson(originalContent []byte, newContent []byte, fs *fsutils.FS) (conte
 	content, err = json.Marshal(result)
 
 	return
-}
-
-func mergeTemplateWithData(project *project, filePath string) (*bytes.Buffer, error) {
-	var templateContent bytes.Buffer
-	content, err := templates.ReadFile(filePath)
-	if err != nil {
-		return &templateContent, err
-	}
-
-	fileTemplate := template.New(filePath)
-	fileTemplate, err = fileTemplate.Parse(string(content))
-	if err != nil {
-		return &templateContent, err
-	}
-
-	if err = fileTemplate.Execute(&templateContent, project); err != nil {
-		return &templateContent, err
-	}
-
-	return &templateContent, nil
 }
 
 func getMainFileName(project *project) string {

--- a/testdata/shopifile.yml
+++ b/testdata/shopifile.yml
@@ -1,4 +1,5 @@
 port: 8000
+store: test-shop.myshopify.com
 app:
   api_key: app_api_key
 extensions:
@@ -14,8 +15,22 @@ extensions:
         name: "@shopify/checkout-ui-extensions"
       entries:
         main: "src/index.tsx"
+      resource:
+        url: "cart/1234"
   - uuid: 00000000-0000-0000-0000-000000000001
-    type: checkout_ui_extension
+    type: product_subscription
+    user:
+      metafields: []
+    development:
+      root_dir: "tmp/checkout_ui_extension"
+      build_dir: "build"
+      template: "typescript-react"
+      renderer:
+        name: "@shopify/admin-ui-extensions"
+      entries:
+        main: "src/index.tsx"
+  - uuid: 00000000-0000-0000-0000-000000000002
+    type: checkout_post_purchase
     user:
       metafields: []
     development:

--- a/testdata/shopifile.yml
+++ b/testdata/shopifile.yml
@@ -38,6 +38,6 @@ extensions:
       build_dir: "build"
       template: "typescript-react"
       renderer:
-        name: "@shopify/checkout-ui-extensions"
+        name: "@shopify/post-purchase-ui-extensions"
       entries:
         main: "src/index.tsx"


### PR DESCRIPTION
- render tunnel error page for post-purchase, checkout and admin extensions when accessed via localhost
- render instructions page for post-purchase extensions when accessed through a tunnel
- redirect to the store's resource url for checkout extensions when accessed through a tunnel
- redirect to the store's admin extensions-dev for admin extensions when accessed through a tunnel

Fix https://github.com/Shopify/shopify-cli-extensions/issues/53

### Tophat
1. Run `make bootstrap`
2. Run `make run serve testdata/shopifile.yml`
3. In another terminal, run `ngrok http 8000` and make a note of your tunnel url

**Checkout**
1. Navigate to http://localhost:8000/extensions/00000000-0000-0000-0000-000000000000 and verify that you see the tunnel error message with the correct link to the extension
![image](https://user-images.githubusercontent.com/29458473/137347689-46c83de2-3630-4fed-92f7-ca6a1699b7bd.png)
2. Navigate to https://TUNNEL_URL/extensions/00000000-0000-0000-0000-000000000000 and verify that you're redirected to https://test-shop.myshopify.com/cart/1234?dev=https://da94-45-3-5-121.ngrok.io/extensions/

**Admin**
1. Navigate to http://localhost:8000/extensions/00000000-0000-0000-0000-000000000001 and verify that you see the tunnel error message with the correct link to the extension
![image](https://user-images.githubusercontent.com/29458473/137348886-cd6b3b24-a07b-49a7-916e-f2f73a9e8aab.png)
2. Navigate to https://TUNNEL_URL/extensions/00000000-0000-0000-0000-000000000001 and verify that you're redirected to https://test-shop.myshopify.com/admin/extensions-dev?url=https://da94-45-3-5-121.ngrok.io/extensions/00000000-0000-0000-0000-000000000001 

**Post purchase**
1. Navigate to http://localhost:8000/extensions/00000000-0000-0000-0000-000000000002 and verify that you see the tunnel error message
![image](https://user-images.githubusercontent.com/29458473/137348919-f7e5669a-df54-4235-9670-a51aeba62d0d.png)
2. Navigate to https://TUNNEL_URL/extensions/00000000-0000-0000-0000-000000000002 and verify that you see the message without tunnel error
![image](https://user-images.githubusercontent.com/29458473/137352087-d5e8b73f-f9d2-428f-a93d-bf3c4e29fd6e.png)
