### PR TITLE
Websocket: send asset urls with updated unix timestamp when assets are compiled successfully

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -12,6 +12,16 @@ func NewExtensionService(config *Config, apiRoot string) *ExtensionService {
 	extensions := []Extension{}
 	for _, extension := range config.Extensions {
 		extension.Assets = make(map[string]Asset)
+		keys := make([]string, 0, len(extension.Development.Entries))
+
+		for key := range extension.Development.Entries {
+			keys = append(keys, key)
+		}
+
+		for entry := range keys {
+			name := keys[entry]
+			extension.Assets[name] = Asset{Name: name}
+		}
 		extensions = append(extensions, extension)
 	}
 	// TODO: Improve this when we need to read more app configs,
@@ -68,8 +78,9 @@ type Extension struct {
 }
 
 type Asset struct {
-	Name string `json:"name" yaml:"name"`
-	Url  string `json:"url" yaml:"url"`
+	Name            string `json:"name" yaml:"name"`
+	Url             string `json:"url" yaml:"url"`
+	RawSearchParams string `json:"-" yaml:"-"`
 }
 
 type Development struct {


### PR DESCRIPTION
Part 1 of https://github.com/Shopify/shopify-cli-extensions/issues/10
- allow subscribers to be notified when assets have been rebuilt as the urls are automatically updated
- subscribers can use the updated urls instead of maintaining their own logic to increase a reload param

### Tophat
1. Run `make bootstrap`
2. Run `make run server testdata/shopifile.yml`
3. Open `http://locahost:8000/extensions` in a browser and open the console paste the following code
    ```js
    var ws = new WebSocket("ws://localhost:8000/extensions/");
     ```
4. Open the network tab, click on the websocket connection and verify that you see a `connected` message with extensions and all assets urls contain a timestamp
![image](https://user-images.githubusercontent.com/29458473/137372446-76fd8ac4-4aff-4a98-8c35-ee8271470744.png)

4. Open `tmp/checkout_ui_extension/src/index.tsx` and make some changes to the file
5. In the browser's network tab verify that you get an `update` message with the extension asset urls updated with a new timestamp
![image](https://user-images.githubusercontent.com/29458473/137372564-af1ee1f1-1d10-465a-8604-c70b2910a7e0.png)
