### PR TITLE
Fix serve command instructions on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To create new extension projects, simply execute the following shell command:
 make run create testdata/shopifile.yml
 ```
 
-This will create a new extension inside the `tmp/checkout_ui_extension` folder. You can update `testdata/shopifile.yml` if you want to test different options.
+This will create new extensions inside the `tmp` folder. You can update `testdata/shopifile.yml` if you want to test different options.
 
 The YAML file is in the format of
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Once the PR for the new branch is merged, you can deploy the packages on [Shipit
 To create new extension projects, simply execute the following shell command:
 
 ```sh
-make run serve testdata/shopifile.yml
+make run create testdata/shopifile.yml
 ```
 
 This will create a new extension inside the `tmp/checkout_ui_extension` folder. You can update `testdata/shopifile.yml` if you want to test different options.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Once the PR for the new branch is merged, you can deploy the packages on [Shipit
 
 ## Create
 
-To create a new extension project, simply execute the following shell command:
+To create new extension projects, simply execute the following shell command:
 
 ```sh
 make run serve testdata/shopifile.yml


### PR DESCRIPTION
There's a typo on the README instructions where the `make serve` command breaks with an unclear runtime error. This PR fixes the README instructions.

## Tophat 🎩 
Follow the instructions on the README to setup the project and you should not see any errors.