### PR TITLE
Checkout integration

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -47,16 +47,26 @@ func TestGetExtensions(t *testing.T) {
 
 	getJSONResponse(api, t, secureHost, "/extensions/", &response)
 
-	if response.App == nil || response.App["api_key"] != "app_api_key" {
-		t.Errorf("Expected app to have api_key \"app_api_key\" but got %v", response.App)
+	if response.App == nil || response.App["apiKey"] != "app_api_key" {
+		t.Errorf("Expected app to have apiKey \"app_api_key\" but got %v", response.App)
 	}
 
 	if len(response.Extensions) != 3 {
 		t.Errorf("Expected 3 extension got %d", len(response.Extensions))
 	}
 
-	if response.Version != "0.1.0" {
-		t.Errorf("expect service version to be 0.1.0 but got %s", response.Version)
+	if response.Version != "3" {
+		t.Errorf("expect service version to be 3 but got %s", response.Version)
+	}
+
+	rootUrl := fmt.Sprintf("https://%s%s", secureHost, api.apiRoot)
+	if response.Root.Url != rootUrl {
+		t.Errorf("expect service root url to be %s but got %s", rootUrl, response.Root.Url)
+	}
+
+	socketUrl := fmt.Sprintf("wss://%s%s", secureHost, api.apiRoot)
+	if response.Socket.Url != socketUrl {
+		t.Errorf("expect service socket url to be %s but got %s", socketUrl, response.Socket.Url)
 	}
 
 	extension := response.Extensions[0]
@@ -95,8 +105,22 @@ func TestGetSingleExtension(t *testing.T) {
 
 	getJSONResponse(api, t, secureHost, "/extensions/00000000-0000-0000-0000-000000000000", &response)
 
-	if response.Version != "0.1.0" {
-		t.Errorf("expect service version to be 0.1.0 but got %s", response.Version)
+	if response.App == nil || response.App["apiKey"] != "app_api_key" {
+		t.Errorf("Expected app to have apiKey \"app_api_key\" but got %v", response.App)
+	}
+
+	if response.Version != "3" {
+		t.Errorf("expect service version to be 3 but got %s", response.Version)
+	}
+
+	rootUrl := fmt.Sprintf("https://%s%s", host, api.apiRoot)
+	if response.Root.Url != rootUrl {
+		t.Errorf("expect service root url to be %s but got %s", rootUrl, response.Root.Url)
+	}
+
+	socketUrl := fmt.Sprintf("wss://%s%s", host, api.apiRoot)
+	if response.Socket.Url != socketUrl {
+		t.Errorf("expect service socket url to be %s but got %s", socketUrl, response.Socket.Url)
 	}
 
 	if response.App == nil {
@@ -434,8 +458,8 @@ func TestWebsocketClientUpdateAppEvent(t *testing.T) {
 		t.Error("Expected app to not be null")
 	}
 
-	if response.App["api_key"] != "app_api_key" {
-		t.Errorf("expected App[\"api_key\"] to be `\"app_api_key\"` but got %v", response.App["api_key"])
+	if response.App["apiKey"] != "app_api_key" {
+		t.Errorf("expected App[\"apiKey\"] to be `\"app_api_key\"` but got %v", response.App["apiKey"])
 	}
 
 	if response.App["title"] != "my app" {
@@ -680,7 +704,8 @@ func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
 		  "metafields": [{"namespace": "another-namespace", "key": "another-key"}],
 		  "uuid": "00000000-0000-0000-0000-000000000000",
 		  "version": "",
-		  "extensionPoints": null
+		  "extensionPoints": null,
+		  "surface": "checkout"
 		}
 	  ]`, server.URL, server.URL)
 

--- a/core/core.go
+++ b/core/core.go
@@ -5,8 +5,15 @@ import (
 	"io"
 	"path/filepath"
 	"reflect"
+	"strings"
 
 	"gopkg.in/yaml.v3"
+)
+
+const (
+	Checkout     string = "checkout"
+	Admin        string = "admin"
+	PostPurchase string = "post-purchase"
 )
 
 func NewExtensionService(config *Config, apiRoot string) *ExtensionService {
@@ -24,6 +31,7 @@ func NewExtensionService(config *Config, apiRoot string) *ExtensionService {
 			name := keys[entry]
 			extension.Assets[name] = Asset{Name: name}
 		}
+		extension.Surface = GetSurface(&extension)
 		extensions = append(extensions, extension)
 	}
 	// TODO: Improve this when we need to read more app configs,
@@ -33,7 +41,7 @@ func NewExtensionService(config *Config, apiRoot string) *ExtensionService {
 
 	service := ExtensionService{
 		App:        app,
-		Version:    "0.1.0",
+		Version:    "3",
 		Extensions: extensions,
 		Port:       config.Port,
 		Store:      config.Store,
@@ -78,6 +86,7 @@ type Extension struct {
 	Type            string           `json:"type" yaml:"type,omitempty"`
 	UUID            string           `json:"uuid" yaml:"uuid,omitempty"`
 	Version         string           `json:"version" yaml:"version,omitempty"`
+	Surface         string           `json:"surface" yaml:"-"`
 }
 
 func (e Extension) String() string {
@@ -136,4 +145,14 @@ func (t Extension) Transformer(typ reflect.Type) func(dst, src reflect.Value) er
 		}
 	}
 	return nil
+}
+
+func GetSurface(extension *Extension) string {
+	if strings.Contains(extension.Development.Renderer.Name, "checkout") {
+		return Checkout
+	}
+	if strings.Contains(extension.Development.Renderer.Name, "post-purchase") {
+		return PostPurchase
+	}
+	return Admin
 }

--- a/create/templates/checkout_ui_extension/react.js
+++ b/create/templates/checkout_ui_extension/react.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import {render, Text} from '@shopify/checkout-ui-extensions-react';
 
-render("Checkout::Feature::Render", App);
+render('Checkout::Feature::Render', App);
 
-function App({ extensionPoint }) {
+function App({extensionPoint}) {
   return <Text>Welcome to the {extensionPoint} extension!</Text>;
 }


### PR DESCRIPTION
Related https://github.com/Shopify/shopify-cli-extensions/issues/10

- Added the root url and socket url to support Checkout's current usage
- Remove the `StrictSlash(true)` setting as it doesn't work when doing a fetch request. We need to manually handle the trailing slash instead
- Fix issue in the checkout_ui_extension template where the React template was missing some imports
- Fix issue where the app response for GET calls does not have its keys in lower camel case