### PR TITLE
Output build information provided by ESBuild

### DIFF
--- a/build/result.go
+++ b/build/result.go
@@ -13,9 +13,5 @@ type Result struct {
 }
 
 func (r Result) String() string {
-	if r.Success {
-		return fmt.Sprintf("Successfully built Extension %s", r.Extension)
-	} else {
-		return fmt.Sprintf("Failed to build Extension %s\n%s", r.Extension, r.Message)
-	}
+	return fmt.Sprintf("%s\n%s", r.Extension, r.Message)
 }

--- a/core/core.go
+++ b/core/core.go
@@ -87,10 +87,18 @@ type Extension struct {
 	UUID            string           `json:"uuid" yaml:"uuid,omitempty"`
 	Version         string           `json:"version" yaml:"version,omitempty"`
 	Surface         string           `json:"surface" yaml:"-"`
+	Title           string           `json:"title,omitempty" yaml:"title,omitempty"`
+	Name            string           `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 func (e Extension) String() string {
-	return fmt.Sprintf("%s (%s)", e.UUID, e.Type)
+	if e.Name != "" {
+		return e.Name
+	} else if e.Title != "" {
+		return e.Title
+	} else {
+		return fmt.Sprintf("%s (%s)", e.Type, e.UUID)
+	}
 }
 
 func (e Extension) BuildDir() string {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -12,6 +12,8 @@ func TestLoadConfig(t *testing.T) {
 extensions:
 	- uuid: 123
 		type: checkout_ui_extension
+		title: Test Extension
+		name: Alternate Name
 `)
 
 	config, err := core.LoadConfig(strings.NewReader(serializedConfig))
@@ -32,6 +34,14 @@ extensions:
 
 	if extension.Type != "checkout_ui_extension" {
 		t.Errorf("invalid extension type – expected checkout_ui_extension got %s", extension.Type)
+	}
+
+	if extension.Title != "Test Extension" {
+		t.Errorf("invalid title - expected Test Extension go %s", extension.Title)
+	}
+
+	if extension.Name != "Alternate Name" {
+		t.Errorf("invalid name - expected Alternate Name go %s", extension.Name)
 	}
 }
 

--- a/testdata/shopifile.yml
+++ b/testdata/shopifile.yml
@@ -5,39 +5,42 @@ app:
 extensions:
   - uuid: 00000000-0000-0000-0000-000000000000
     type: checkout_ui_extension
+    title: Checkout UI Test Extension
     metafields:
       - namespace: my-namespace
         key: my-key
     development:
-      root_dir: "tmp/checkout_ui_extension"
-      build_dir: "build"
-      template: "typescript-react"
+      root_dir: 'tmp/checkout_ui_extension'
+      build_dir: 'build'
+      template: 'typescript-react'
       renderer:
-        name: "@shopify/checkout-ui-extensions"
+        name: '@shopify/checkout-ui-extensions'
       entries:
-        main: "src/index.tsx"
+        main: 'src/index.tsx'
       resource:
-        url: "cart/1234"
+        url: 'cart/1234'
   - uuid: 00000000-0000-0000-0000-000000000001
     type: product_subscription
+    title: Product Subscription Test Extension
     development:
-      root_dir: "tmp/product_subscription"
-      build_dir: "build"
-      template: "typescript-react"
+      root_dir: 'tmp/product_subscription'
+      build_dir: 'build'
+      template: 'typescript-react'
       renderer:
-        name: "@shopify/admin-ui-extensions"
+        name: '@shopify/admin-ui-extensions'
       entries:
-        main: "src/index.tsx"
+        main: 'src/index.tsx'
   - uuid: 00000000-0000-0000-0000-000000000002
     type: checkout_post_purchase
+    title: Post Purchase Test Extension
     metafields:
       - namespace: my-namespace
         key: my-key
     development:
-      root_dir: "tmp/checkout_post_purchase"
-      build_dir: "build"
-      template: "typescript-react"
+      root_dir: 'tmp/checkout_post_purchase'
+      build_dir: 'build'
+      template: 'typescript-react'
       renderer:
-        name: "@shopify/post-purchase-ui-extensions"
+        name: '@shopify/post-purchase-ui-extensions'
       entries:
-        main: "src/index.tsx"
+        main: 'src/index.tsx'


### PR DESCRIPTION
This changes `build.Result.Message` to include the output generated by ESBuild on a successful build.

<img width="293" alt="Screen Shot 2021-11-05 at 11 20 26 AM" src="https://user-images.githubusercontent.com/77060/140534808-46daa299-e050-4007-b487-69512025e351.png">

If present, the header use the extension name, otherwise its title and lastly falls back to `<Type> (<UUID>)`. When running in watch mode, file names are omitted.

Related to #91.

**Outstanding work**

Remove `Build was successful!` from Shopify CLI in favour of the more complete message being generated by the development server.