### PR TITLE
Feature/link-component-2

### DIFF
--- a/packages/ui-extensions-server-kit/jest.config.ts
+++ b/packages/ui-extensions-server-kit/jest.config.ts
@@ -20,6 +20,7 @@ const config: Config.InitialOptions = {
 
   moduleNameMapper: {
     'tests/(.*)': '<rootDir>/tests/$1',
+    '\\.(scss)$': '<rootDir>/src/__mocks__/styleMock.js',
   },
 
   moduleDirectories: ['node_modules', 'src'],

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@shopify/ui-extensions-server-kit",
   "version": "0.1.0-alpha.0",
+  "license": "UNLICENSED",
   "main": "dist/index",
   "types": "dist/index",
   "scripts": {
     "build": "tsc",
-    "test": "jest",
+    "test": "jest --watch",
     "clean": "git clean --exclude node_modules -xdf ./",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"

--- a/packages/ui-extensions-server-kit/src/__mocks__/styleMock.js
+++ b/packages/ui-extensions-server-kit/src/__mocks__/styleMock.js
@@ -1,0 +1,3 @@
+module.exports = {
+  monochrome: 'monochrome',
+};

--- a/packages/ui-extensions-server-kit/src/components/Link/Link.scss
+++ b/packages/ui-extensions-server-kit/src/components/Link/Link.scss
@@ -1,0 +1,9 @@
+.Link {
+  color: var(--p-interactive);
+  cursor: pointer;
+}
+
+.monochrome {
+  color: inherit;
+  text-decoration: underline;
+}

--- a/packages/ui-extensions-server-kit/src/components/Link/Link.test.tsx
+++ b/packages/ui-extensions-server-kit/src/components/Link/Link.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import {mount} from '@shopify/react-testing';
+import '@shopify/react-testing/matchers';
+
+import {Link, LinkProps} from './Link';
+
+describe('<Link />', () => {
+  const to: LinkProps['to'] = 'https://example.com';
+
+  it('renders an an anchor', () => {
+    const link = mount(<Link to={to} />);
+
+    expect(link).toContainReactComponent('a', {href: 'https://example.com'});
+  });
+
+  it('opens to a new tab when "external" is true', () => {
+    const link = mount(<Link to={to} external />);
+
+    expect(link).toContainReactComponent('a', {target: '_blank', rel: 'noreferrer'});
+  });
+
+  it('renders an anchor with aria-label when provided', () => {
+    const accessibilityLabel = 'Accessibility label';
+    const link = mount(<Link to={to} accessibilityLabel={accessibilityLabel} />);
+
+    expect(link).toContainReactComponent('a', {
+      'aria-label': accessibilityLabel,
+    });
+  });
+
+  it('does not render with aria-label when not provided', () => {
+    const link = mount(<Link to={to} accessibilityLabel={undefined} />);
+
+    expect(link).toContainReactComponent('a', {
+      'aria-label': undefined,
+    });
+  });
+
+  it('renders with a lang attribute when language is provided', () => {
+    const link = mount(<Link to={to} language="fr" />);
+
+    expect(link).toContainReactComponent('a', {
+      lang: 'fr',
+    });
+  });
+
+  it('renders a monochrome link when appearance="monochrome"', () => {
+    const link = mount(<Link to={to} appearance="monochrome" />);
+
+    expect(link).toContainReactComponent('a', {
+      className: 'monochrome',
+    });
+  });
+});

--- a/packages/ui-extensions-server-kit/src/components/Link/Link.tsx
+++ b/packages/ui-extensions-server-kit/src/components/Link/Link.tsx
@@ -1,0 +1,68 @@
+import React, {PropsWithChildren} from 'react';
+
+import {classNames} from '../../utilities';
+
+import styles from './Link.scss';
+
+export interface LinkProps {
+  /**
+   * Specify the color of the link.
+   * `monochrome` will take the color of its parent.
+   */
+  appearance?: 'monochrome';
+  /**
+   * Destination to navigate to. You **must** provide either this property, `onPress`,
+   * or both.
+   */
+  to: string;
+  /** Open the link in a new window or tab */
+  external?: boolean;
+  /**
+   * Unique identifier. Typically used as a target for another component’s controls
+   * to associate an accessible label with an action.
+   */
+  id?: string;
+  /**
+   * Indicate the text language. Useful when the text is in a different language than the rest of the page.
+   * It will allow assistive technologies such as screen readers to invoke the correct pronunciation.
+   * Reference of values: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry (see "subtag")
+   */
+  language?: string;
+  /**
+   * A label used for buyers using assistive technologies. When provided, any
+   * 'children' supplied to this component are hidden from being seen for
+   * accessibility purposes to prevent duplicate content from being read.
+   */
+  accessibilityLabel?: string;
+}
+
+/**
+ * Link is used to navigate user to another page.
+ */
+export function Link({
+  appearance,
+  accessibilityLabel,
+  children,
+  external,
+  id,
+  language,
+  to,
+}: PropsWithChildren<LinkProps>) {
+  const openInNewTabProps = external && {
+    target: '_blank',
+    rel: 'noreferrer',
+  };
+
+  return (
+    <a
+      href={to}
+      className={classNames(styles.Link, appearance === 'monochrome' && styles.monochrome)}
+      aria-label={accessibilityLabel}
+      id={id}
+      lang={language}
+      {...openInNewTabProps}
+    >
+      {children}
+    </a>
+  );
+}

--- a/packages/ui-extensions-server-kit/src/components/Link/index.ts
+++ b/packages/ui-extensions-server-kit/src/components/Link/index.ts
@@ -1,0 +1,2 @@
+export {Link} from './Link';
+export type {LinkProps} from './Link';

--- a/packages/ui-extensions-server-kit/src/components/Link/stories/Link_accessibility_label.stories.tsx
+++ b/packages/ui-extensions-server-kit/src/components/Link/stories/Link_accessibility_label.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Meta, Story} from '@storybook/react/types-6-0';
+
+import {Link, LinkProps} from '../Link';
+
+const meta = {
+  component: Link,
+  title: 'components/Link',
+} as Meta;
+
+export default meta;
+
+const Template: Story<LinkProps> = (args) => {
+  return (
+    <>
+      <Link {...args}>Visit Shopify.com</Link> (inspect for accessibility label)
+    </>
+  );
+};
+
+export const AccessibilityLabel = Template.bind({});
+
+AccessibilityLabel.args = {
+  accessibilityLabel: 'Visit Shopify.com',
+  to: 'https://shopify.com',
+};

--- a/packages/ui-extensions-server-kit/src/components/Link/stories/Link_external.stories.tsx
+++ b/packages/ui-extensions-server-kit/src/components/Link/stories/Link_external.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Meta, Story} from '@storybook/react/types-6-0';
+
+import {Link, LinkProps} from '../Link';
+
+const meta = {
+  component: Link,
+  title: 'components/Link',
+} as Meta;
+
+export default meta;
+
+const Template: Story<LinkProps> = (args) => {
+  return (
+    <>
+      <Link {...args}>External Link</Link> (opens in a new tab)
+    </>
+  );
+};
+
+export const External = Template.bind({});
+
+External.args = {
+  external: true,
+  to: 'https://shopify.com',
+};

--- a/packages/ui-extensions-server-kit/src/components/Link/stories/Link_language.stories.tsx
+++ b/packages/ui-extensions-server-kit/src/components/Link/stories/Link_language.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Meta, Story} from '@storybook/react/types-6-0';
+
+import {Link, LinkProps} from '..';
+
+const meta = {
+  component: Link,
+  title: 'components/Link',
+} as Meta;
+
+export default meta;
+
+const Template: Story<LinkProps> = (args) => {
+  return (
+    <>
+      <Link {...args}>enlace Español</Link> (inspect for lang attribute)
+    </>
+  );
+};
+
+export const Language = Template.bind({});
+
+Language.args = {
+  language: 'es',
+  to: 'https://shopify.com',
+};

--- a/packages/ui-extensions-server-kit/src/components/Link/stories/Link_monochrome.stories.tsx
+++ b/packages/ui-extensions-server-kit/src/components/Link/stories/Link_monochrome.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Meta, Story} from '@storybook/react/types-6-0';
+
+import {Link, LinkProps} from '../Link';
+
+const meta = {
+  component: Link,
+  title: 'components/Link',
+} as Meta;
+
+export default meta;
+
+const Template: Story<LinkProps> = (args) => {
+  return (
+    <span style={{color: 'yellow'}}>
+      Learn more about our <Link {...args}>shipping policies</Link> (monochrome link)
+    </span>
+  );
+};
+
+export const Monochrome = Template.bind({});
+
+Monochrome.args = {
+  appearance: 'monochrome',
+  to: 'https://shopify.com',
+};

--- a/packages/ui-extensions-server-kit/src/components/Link/stories/Link_standard.stories.tsx
+++ b/packages/ui-extensions-server-kit/src/components/Link/stories/Link_standard.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {Meta, Story} from '@storybook/react/types-6-0';
+
+import {Link, LinkProps} from '../Link';
+
+const meta = {
+  component: Link,
+  title: 'components/Link',
+} as Meta;
+
+export default meta;
+
+const Template: Story<LinkProps> = (args) => {
+  return (
+    <>
+      <Link {...args}>Visit Shopify.com</Link> (opens in this tab)
+    </>
+  );
+};
+
+export const Standard = Template.bind({});
+
+Standard.args = {
+  to: 'https://shopify.com',
+};

--- a/packages/ui-extensions-server-kit/src/styles/theme.module.scss
+++ b/packages/ui-extensions-server-kit/src/styles/theme.module.scss
@@ -38,7 +38,7 @@
   --p-text: rgba(255, 255, 255, 1);
   --p-text-disabled: rgba(140, 145, 150, 1);
   --p-text-subdued: rgba(109, 113, 117, 1);
-  --p-interactive: hsl(207, 100%, 60%);
+  --p-interactive: hsl(207, 100%, 70%);
 
   // TODO: change to new interactive values or remove
   --p-interactive-disabled: rgba(189, 193, 204, 1);
@@ -209,7 +209,8 @@
     Remove list styles (bullets/numbers)
     in case you use it combine with normalize.css
   */
-  ol, ul {
+  ol,
+  ul {
     list-style: none;
   }
 


### PR DESCRIPTION
## Background

Closes Component: https://github.com/Shopify/shopify-cli-extensions/issues/113

## Solution

- Add a`Link` component to the dev console component library
- Add `styleMock`
- Lighten `--p-interactive` to support a11y 

https://user-images.githubusercontent.com/7654369/140074183-eed59f54-cb77-4fe2-8965-caa9b57bb470.mov

## 🎩

- Navigate to `packages/dev-console`
- Run `yarn storybook`
- Review`Link` stories