### PR TITLE
Remove served from column

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This will create extensions in the `tmp` folder and install the node dependencie
 After [boostrapping an extension](#bootstrap-an-extension), you can run the server by execute the following shell command:
 
 ```sh
-make run serve < testdata/shopifile.yml
+make run serve testdata/shopifile.yml
 ```
 
 Subsequently, you should be able to retrieve sample assets as follows:
@@ -70,7 +70,7 @@ make serve-dev
 To create a new extension project, simply execute the following shell command:
 
 ```sh
-make run serve < testdata/shopifile.yml
+make run serve testdata/shopifile.yml
 ```
 
 This will create a new extension inside the `tmp/checkout_ui_extension` folder. You can update `testdata/shopifile.yml` if you want to test different options.

--- a/packages/dev-console-app/src/DevConsole.tsx
+++ b/packages/dev-console-app/src/DevConsole.tsx
@@ -143,7 +143,6 @@ export function DevConsole() {
                       </th>
                       <th>{i18n.translate('extensionList.name')}</th>
                       <th>{i18n.translate('extensionList.type')}</th>
-                      <th>{i18n.translate('extensionList.servedFrom')}</th>
                       <th>{i18n.translate('extensionList.status')}</th>
                       <th>
                         <div className={actionSetStyles.ActionGroup}>

--- a/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
+++ b/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
@@ -35,12 +35,6 @@ export function ExtensionRow({
 
   const {name, url: scriptUrl} = assets.main;
 
-  const scriptHost = useMemo(() => {
-    if (!scriptUrl) return null;
-    const url = new URL(scriptUrl.toString());
-    return `${url.protocol}//${url.host}`;
-  }, [scriptUrl]);
-
   const handleSelect = useCallback(
     (event?: MouseEvent) => {
       if (event) event.stopPropagation();
@@ -64,11 +58,6 @@ export function ExtensionRow({
       </td>
       <td className={textClass}>{name}</td>
       <td className={textClass}>{extension.type}</td>
-      <td className={textClass}>
-        <a className={styles.Url} href={scriptHost || '#'}>
-          {scriptHost}
-        </a>
-      </td>
       <td>
         <span className={`${styles.Status} ${statusClass}`}>
           {i18n.translate(`statuses.${status}`)}

--- a/packages/dev-console-app/src/translations/en.json
+++ b/packages/dev-console-app/src/translations/en.json
@@ -5,7 +5,6 @@
     "title": "Local overrides",
     "name": "Name",
     "type": "Type",
-    "servedFrom": "Served from",
     "status": "Status",
     "refresh": "Refresh",
     "delete": "Delete"


### PR DESCRIPTION
Closes: https://github.com/Shopify/shopify-cli-extensions/issues/166

This PR removes the served from column since the link out action has been added.