### PR TITLE
Adding base description to Icon and Checkbox

### DIFF
--- a/packages/ui-extensions-server-kit/src/components/CheckBox/Checkbox.tsx
+++ b/packages/ui-extensions-server-kit/src/components/CheckBox/Checkbox.tsx
@@ -30,7 +30,7 @@ interface CheckboxPropsBase {
 
 export type CheckboxProps = PropsWithChildren<CheckboxPropsBase>;
 
-/** Checkboxes are used to give users a way to make a range of selections (zero, one, or multiple).
+/** Checkbox is used to give users a way to make a range of selections (zero, one, or multiple).
  */
 export function Checkbox({
   id: explicitId,

--- a/packages/ui-extensions-server-kit/src/components/CheckBox/Checkbox.tsx
+++ b/packages/ui-extensions-server-kit/src/components/CheckBox/Checkbox.tsx
@@ -30,6 +30,8 @@ interface CheckboxPropsBase {
 
 export type CheckboxProps = PropsWithChildren<CheckboxPropsBase>;
 
+/** Checkboxes are used to give users a way to make a range of selections (zero, one, or multiple).
+ */
 export function Checkbox({
   id: explicitId,
   name,

--- a/packages/ui-extensions-server-kit/src/components/Icon/Icon.tsx
+++ b/packages/ui-extensions-server-kit/src/components/Icon/Icon.tsx
@@ -57,7 +57,7 @@ export interface IconProps {
   accessibilityLabel?: string;
 }
 
-/** Icons are used to visually communicate core parts of the developer console and available actions.
+/** Icon is used to visually communicate core parts of the developer console and available actions.
 
 */
 export function Icon({source, size, kind = 'base', accessibilityLabel}: IconProps) {

--- a/packages/ui-extensions-server-kit/src/components/Icon/Icon.tsx
+++ b/packages/ui-extensions-server-kit/src/components/Icon/Icon.tsx
@@ -57,6 +57,9 @@ export interface IconProps {
   accessibilityLabel?: string;
 }
 
+/** Icons are used to visually communicate core parts of the developer console and available actions.
+
+*/
 export function Icon({source, size, kind = 'base', accessibilityLabel}: IconProps) {
   if (kind && typeof source !== 'function') {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
issue: #184 

Here are the descriptions for Icon and Checkbox:

<img width="686" alt="Screen Shot 2021-11-11 at 1 03 10 PM" src="https://user-images.githubusercontent.com/90475219/141368877-a07e5203-8079-4c6c-a53b-663aeb5b33b3.png">

<img width="825" alt="Screen Shot 2021-11-11 at 1 03 04 PM" src="https://user-images.githubusercontent.com/90475219/141368891-cf8e824f-fec3-41d6-98e2-0bb2e172e9a7.png">

