### PR TITLE
change tsconfig target to es2015

### DIFF
--- a/packages/shopify-cli-extensions/tsconfig.json
+++ b/packages/shopify-cli-extensions/tsconfig.json
@@ -1,12 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["es2020"],
+    "target": "es2015",
     "module": "commonjs",
-    "target": "es2019",
     "rootDir": "./src",
     "composite": true,
     "outDir": "./",
-    "allowJs": false,
     "declaration": true,
     "strict": true,
     "moduleResolution": "node",


### PR DESCRIPTION
## Background

Running `make bootstrap` was causing issues with conflicts between the dependencies across packages. 

## Solution

Downgrading the target of the ts build in `shopify-cli-extensions` resolves the error.

## 🎩

Run `make bootstrap` and confirm that there are no errors. 