### PR TITLE
Move timestamp to a separate prop instead of appending it to the asset url

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -216,8 +216,8 @@ func (api *ExtensionsApi) Notify(extensions []core.Extension) {
 			if castedData.Development.Status == "success" {
 				for entry := range api.Extensions[index].Assets {
 					api.Extensions[index].Assets[entry] = core.Asset{
-						Name:            api.Extensions[index].Assets[entry].Name,
-						RawSearchParams: fmt.Sprintf("?timestamp=%d", time.Now().Unix()),
+						Name:        api.Extensions[index].Assets[entry].Name,
+						LastUpdated: time.Now().Unix(),
 					}
 				}
 			}
@@ -263,7 +263,7 @@ func configureExtensionsApi(config *core.Config, router *mux.Router, apiRoot str
 	api.PathPrefix("/assets/").Handler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		http.Redirect(rw, r, path.Join("/dev-console", r.URL.Path), http.StatusPermanentRedirect)
 	}))
-	
+
 	return api
 }
 
@@ -450,12 +450,11 @@ func setExtensionUrls(original core.Extension, rootUrl string) core.Extension {
 
 	for entry := range extension.Assets {
 		name := extension.Assets[entry].Name
-		rawSearchParams := extension.Assets[entry].RawSearchParams
 
 		extension.Assets[entry] = core.Asset{
-			RawSearchParams: rawSearchParams,
-			Url:             fmt.Sprintf("%s/assets/%s.js%s", extension.Development.Root.Url, name, rawSearchParams),
-			Name:            name,
+			LastUpdated: extension.Assets[entry].LastUpdated,
+			Url:         fmt.Sprintf("%s/assets/%s.js", extension.Development.Root.Url, name),
+			Name:        name,
 		}
 	}
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -300,7 +300,7 @@ func TestWebsocketNotify(t *testing.T) {
 	}
 }
 
-func TestWebsocketNotifyBuildStatusWithReloadParam(t *testing.T) {
+func TestWebsocketNotifyBuildStatusWithLastUpdatedValue(t *testing.T) {
 	api := New(config, apiRoot)
 	server := httptest.NewServer(api)
 
@@ -327,8 +327,8 @@ func TestWebsocketNotifyBuildStatusWithReloadParam(t *testing.T) {
 		t.Errorf("expecting extensions Development.Status to be success but received %v", first_success[0].Development.Status)
 	}
 
-	if !strings.Contains(first_success[0].Assets["main"].Url, "?timestamp=") {
-		t.Errorf("expecting extension Assets[\"main\"].Url to contain timestamp param but received %v", first_success[0].Assets["main"].Url)
+	if first_success[0].Assets["main"].LastUpdated <= 0 {
+		t.Errorf("expecting extension Assets[\"main\"].LastUpdated to contain timestamp but received %v", first_success[0].Assets["main"].LastUpdated)
 	}
 
 	duration := 1 * time.Second
@@ -347,13 +347,13 @@ func TestWebsocketNotifyBuildStatusWithReloadParam(t *testing.T) {
 		t.Errorf("expecting extension Development.Status to be success but received %v", second_success[0].Development.Status)
 	}
 
-	if !strings.Contains(second_success[0].Assets["main"].Url, "?timestamp=") {
-		t.Errorf("expecting extension Assets[\"main\"].Url to contain a timestamp param but received %v", second_success[0].Assets["main"].Url)
+	if second_success[0].Assets["main"].LastUpdated <= 0 {
+		t.Errorf("expecting extension Assets[\"main\"].LastUpdated to contain timestamp but received %v", second_success[0].Assets["main"].LastUpdated)
 	}
 
-	if second_success[0].Assets["main"].Url == first_success[0].Assets["main"].Url {
-		t.Logf("previous extension Assets[\"main\"].Url %s", first_success[0].Assets["main"].Url)
-		t.Errorf("expecting extension Assets[\"main\"].Url to be updated with a new timestamp param but received %v", second_success[0].Assets["main"].Url)
+	if second_success[0].Assets["main"].LastUpdated == first_success[0].Assets["main"].LastUpdated {
+		t.Logf("previous extension Assets[\"main\"].LastUpdated %d", first_success[0].Assets["main"].LastUpdated)
+		t.Errorf("expecting extension Assets[\"main\"].LastUpdated to be updated with a new timestamp but received %v", second_success[0].Assets["main"].LastUpdated)
 	}
 
 	<-time.After(duration)
@@ -698,7 +698,8 @@ func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
 		  "assets": {
 			"main": {
 			  "name": "main",
-			  "url": "%v/extensions/00000000-0000-0000-0000-000000000000/assets/main.js"
+			  "url": "%v/extensions/00000000-0000-0000-0000-000000000000/assets/main.js",
+			  "lastUpdated": 0
 			}
 		  },
 		  "development": {

--- a/core/core.go
+++ b/core/core.go
@@ -106,9 +106,9 @@ func (e Extension) BuildDir() string {
 }
 
 type Asset struct {
-	Name            string `json:"name" yaml:"name"`
-	Url             string `json:"url" yaml:"url"`
-	RawSearchParams string `json:"-" yaml:"-"`
+	Name        string `json:"name" yaml:"name"`
+	Url         string `json:"url" yaml:"url"`
+	LastUpdated int64  `json:"lastUpdated" yaml:"lastUpdated"`
 }
 
 type commandConfig struct {


### PR DESCRIPTION
Related to https://github.com/Shopify/shopify-cli-extensions/issues/10

Move timestamp prop to `lastUpdated` so that the asset url remain unchanged as expected. Consumers that needs to check the last updated time can still access to it through `lastUpdated` in order to handle reloading the extension