### PR TITLE
Update `build` command on `ui-extensions-server-kit`

### DIFF
--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -7,12 +7,9 @@
     "**"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --emitDeclarationOnly && esbuild src/index.ts --bundle --outfile=dist/index.js --external:react --minify --format=cjs",
     "clean": "git clean --exclude node_modules -xdf ./",
     "test": "jest"
-  },
-  "dependencies": {
-    "@shopify/react-i18n": "^6.1.0"
   },
   "peerDependencies": {
     "react": "16.14.0"

--- a/packages/ui-extensions-server-kit/src/typings.d.ts
+++ b/packages/ui-extensions-server-kit/src/typings.d.ts
@@ -1,2 +1,0 @@
-declare module '*.scss';
-declare module '*.css';


### PR DESCRIPTION
## Summary

While wiring the new Dev Console client on web, an issue was identified which lead to failed SSR of Web. After some investigation, the issue seems to be related to the built output from the transpiler use in `ui-extensions-server-kit` library. To confirm that, a few checks were made.

## Attempts

### 1. Issue reproduction
- **Summary:** The code was imported from the published `0.1.0-alpha.6` of the `@shopify/ui-extensions-server-kit` library.
- **Result:** SSR was not functional ❌ 

### 2. Code imported from inside `web`
- **Summary:** The code from `src` was moved directly into web and the references to `@shopify/ui-extensions-server-kit` were replaced with relative imports.
- **Result:** SSR was functional ✅ 

### 3. Code was transpiled with `esbuild`
- **Summary:** The `ui-extensions-server-kit` library was built using `esbuild` instead of `tsc`. The build was manually moved into `web`'s `node_modules`.
- **Result:** SSR was functional ✅ 


### 4. Code transpiled with `esbuild` and publishe
- **Summary:** The `ui-extensions-server-kit` library was built using `esbuild` instead of `tsc`. The build was published into the internal NPM and pulled in from `web`.
- **Result:** TODO ❓ 

## Proposed solution

Considering this project is delayed, this draft PR proposes the use of `esbuild` to bundle the code as a commonjs bundle and use `tsc` only for generating the library types. From the tests above, this solution seems to fix the issue observed with the `tsc` build.

![Screen Shot 2022-01-18 at 2 34 20 PM](https://user-images.githubusercontent.com/10423749/150015365-b0349cda-fbea-426d-87c5-23dd4dcf0b60.png)

> NOTE: While this works, it might be better to have a future iteration which would generate multiple outputs including TS types, CJS, ESM and UMD.