### PR TITLE
Pass Extension Config from Go to JS via STDIN

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -3,6 +3,7 @@ package build
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"sync"
@@ -19,7 +20,7 @@ func Build(extension core.Extension, report ResultHandler) {
 	}
 
 	if err := configureScript(script, extension); err != nil {
-		report(Result{false, "Unable to serialize extension configuration information", extension})
+		report(Result{false, err.Error(), extension})
 	}
 	ensureBuildDirectoryExists(extension)
 
@@ -48,7 +49,7 @@ func Watch(extension core.Extension, report ResultHandler) {
 	stderr, _ := script.StderrPipe()
 
 	if err := configureScript(script, extension); err != nil {
-		report(Result{false, "Unable to serialize extension configuration information", extension})
+		report(Result{false, err.Error(), extension})
 	}
 	ensureBuildDirectoryExists(extension)
 
@@ -90,7 +91,7 @@ func ensureBuildDirectoryExists(ext core.Extension) {
 func configureScript(script *exec.Cmd, extension core.Extension) error {
 	data, err := yaml.Marshal(extension)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to serialize extension configuration information: %w", err)
 	}
 	script.Stdin = bytes.NewReader(data)
 	return nil

--- a/build/build.go
+++ b/build/build.go
@@ -47,6 +47,9 @@ func Watch(extension core.Extension, report ResultHandler) {
 	stdout, _ := script.StdoutPipe()
 	stderr, _ := script.StderrPipe()
 
+	if err := configureScript(script, extension); err != nil {
+		report(Result{false, "Unable to serialize extension configuration information", extension})
+	}
 	ensureBuildDirectoryExists(extension)
 
 	script.Start()

--- a/packages/shopify-cli-extensions/src/configs.ts
+++ b/packages/shopify-cli-extensions/src/configs.ts
@@ -45,11 +45,11 @@ const RESERVE_PATHS = flattenPaths({
   },
 });
 
-const STDIN = 0;
+export function getConfigs() {
+  const stdin = 0;
 
-export function getConfigs(source: string | number = STDIN) {
   try {
-    const configs = load(readFileSync(source, 'utf8'));
+    const configs = load(readFileSync(stdin, 'utf8'));
     if (!isValidConfigs(configs, REQUIRED_CONFIGS)) {
       throw new Error('Invalid configuration');
     }

--- a/packages/shopify-cli-extensions/src/configs.ts
+++ b/packages/shopify-cli-extensions/src/configs.ts
@@ -47,7 +47,7 @@ const RESERVE_PATHS = flattenPaths({
 
 export function getConfigs() {
   try {
-    const configs = load(readFileSync('shopifile.yml', 'utf8'));
+    const configs = load(readFileSync(0, 'utf8'));
     if (!isValidConfigs(configs, REQUIRED_CONFIGS)) {
       throw new Error('Invalid configuration');
     }

--- a/packages/shopify-cli-extensions/src/configs.ts
+++ b/packages/shopify-cli-extensions/src/configs.ts
@@ -11,7 +11,7 @@ export interface Configs {
   extensionPoints?: string[];
 }
 
-export interface Shopifile {
+export interface ConfigFile {
   development: Development;
   extension_points?: string[];
 }
@@ -45,9 +45,11 @@ const RESERVE_PATHS = flattenPaths({
   },
 });
 
-export function getConfigs() {
+const STDIN = 0;
+
+export function getConfigs(source: string | number = STDIN) {
   try {
-    const configs = load(readFileSync(0, 'utf8'));
+    const configs = load(readFileSync(source, 'utf8'));
     if (!isValidConfigs(configs, REQUIRED_CONFIGS)) {
       throw new Error('Invalid configuration');
     }
@@ -66,7 +68,7 @@ function isValidConfigs(
   configs: any,
   requiredConfigs: RequiredConfigs,
   paths: string[] = [],
-): configs is Shopifile {
+): configs is ConfigFile {
   Object.keys(requiredConfigs).forEach((key) => {
     const isRequired = requiredConfigs[key] !== false;
     const value = configs[key];


### PR DESCRIPTION
This PR changes how we obtain the extension configuration on the JavaScript side. Instead of reading it from disk, the Go server is now expected to supply it via STDIN.

Fixes #212 