### PR TITLE
Fix mjs file path resolution

### DIFF
--- a/packages/ui-extensions-server-kit/scripts/createEntryFiles.ts
+++ b/packages/ui-extensions-server-kit/scripts/createEntryFiles.ts
@@ -35,7 +35,7 @@ export function createEntryFiles(options: CreateEntryFilesOptions): Plugin {
             );
           }
           if (format === 'es') {
-            writeFileSync(cwd(`${key}.mjs`), `export * from './${relative(cwd(), path)}.es';\n`);
+            writeFileSync(cwd(`${key}.mjs`), `export * from './${relative(cwd(), path)}.es.js';\n`);
           }
         });
       });


### PR DESCRIPTION
We should be using the fully qualified file extension when importing inside esm modules. 

This is currently blocking our webpack 5 builds: https://buildkite.com/shopify/web-staging-builder/builds/2906#8c0950aa-32a7-4aed-8acf-3272e3ce13f2/173-177

🙇 