### PR TITLE
Do not configure build_dir by default

### DIFF
--- a/create/templates/extension.config.yml.tpl
+++ b/create/templates/extension.config.yml.tpl
@@ -4,4 +4,3 @@ development:
     {{- range $key, $value := .Development.Entries}}
     {{$key}}: "{{$value}}"
     {{- end}}
-  build_dir: "{{ .Development.BuildDir }}"


### PR DESCRIPTION
While users still have the option to specify a custom `build_dir` in the
extension.config.yml file, it is no longer configured by default.
Instead, we're now relying on `shopify-cli` to provide a default value
via STDIN.
