### PR TITLE
Switch to Yarn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,17 +69,23 @@ build-node-packages:
 
 .PHONY: bootstrap
 bootstrap: tmp build
-	cd packages/shopify-cli-extensions; npm link --force
+	chmod +x packages/shopify-cli-extensions/cli.js
 	./shopify-extensions create testdata/extension.config.yml
-	cd tmp/checkout_ui_extension; npm install && npm link "@shopify/shopify-cli-extensions"
-	cd tmp/product_subscription; npm install && npm link "@shopify/shopify-cli-extensions"
-	cd tmp/checkout_post_purchase; npm install && npm link "@shopify/shopify-cli-extensions"
+	cd tmp/checkout_ui_extension; yarn install
+	cd tmp/checkout_ui_extension; rm -r node_modules/@shopify/shopify-cli-extensions
+	cd tmp/checkout_ui_extension; cp -r ../../packages/shopify-cli-extensions node_modules/@shopify/shopify-cli-extensions
+	cd tmp/product_subscription; yarn install
+	cd tmp/product_subscription; rm -r node_modules/@shopify/shopify-cli-extensions
+	cd tmp/product_subscription; cp -r ../../packages/shopify-cli-extensions node_modules/@shopify/shopify-cli-extensions
+	cd tmp/checkout_post_purchase; yarn install
+	cd tmp/checkout_post_purchase; rm -r node_modules/@shopify/shopify-cli-extensions
+	cd tmp/checkout_post_purchase; cp -r ../../packages/shopify-cli-extensions node_modules/@shopify/shopify-cli-extensions
 
 .PHONY: integration-test
 integration-test: tmp build
-	cd packages/shopify-cli-extensions; npm link --force
+	chmod +x packages/shopify-cli-extensions/cli.js
 	./shopify-extensions create testdata/extension.config.integration.yml
-	cd tmp/integration_test; npm install
+	cd tmp/integration_test; yarn install
 	cd tmp/integration_test; rm -r node_modules/@shopify/shopify-cli-extensions
 	cd tmp/integration_test; cp -r ../../packages/shopify-cli-extensions node_modules/@shopify/shopify-cli-extensions
 	cd tmp/integration_test; cat extension.config.yml | \
@@ -95,7 +101,7 @@ tmp:
 	mkdir tmp
 
 clean:
-	( test -d node_modules && npm run clean ) || true
+	( test -d node_modules && yarn run clean ) || true
 	( test -d tmp && rm -r tmp/ ) || true
 
 clobber: clean


### PR DESCRIPTION
- Switch from NPM to Yarn for _bootstrap_ and _integration-test_ targets
- Replace node linking with file copy
- Manually change CLI executable permission due to yarn not setting executable permission on the binary (Yarn bug on M1 Macs?)