### PR TITLE
Default dev entry main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ integration-test: tmp build
 	cd tmp/integration_test; rm -r node_modules/@shopify/shopify-cli-extensions
 	cd tmp/integration_test; cp -r ../../packages/shopify-cli-extensions node_modules/@shopify/shopify-cli-extensions
 	cd tmp/integration_test; cat extension.config.yml | \
-		ruby -ryaml -e "puts({'extensions' => [YAML.load(STDIN.read).merge({'type' => 'integration_test'})]}.to_yaml)" | \
+		ruby ../../support/merge_config.rb | \
 		../../shopify-extensions build -
 	test -f tmp/integration_test/build/main.js
 

--- a/create/create_test.go
+++ b/create/create_test.go
@@ -56,10 +56,6 @@ func TestMergeTemplatesYAML(t *testing.T) {
 		t.Errorf("expect build directory to be set to \"build\" but it was set to %v", config.Development.BuildDir)
 	}
 
-	if config.Development.Entries["main"] != "src/index.tsx" {
-		t.Errorf("expect main entry to be \"src/index\" but received %v", config.Development.Entries["main"])
-	}
-
 	if len(config.ExtensionPoints) != 1 {
 		t.Errorf("expect extension points to have length of 1 but received %v", len(config.ExtensionPoints))
 	}

--- a/create/templates/extension.config.yml.tpl
+++ b/create/templates/extension.config.yml.tpl
@@ -1,7 +1,3 @@
 ---
 development:
-  entries:
-    {{- range $key, $value := .Development.Entries}}
-    {{$key}}: "{{$value}}"
-    {{- end}}
   build_dir: "{{ .Development.BuildDir }}"

--- a/support/merge_config.rb
+++ b/support/merge_config.rb
@@ -1,0 +1,11 @@
+require 'yaml'
+
+config = YAML.load(STDIN.read).tap do |config|
+  config['type'] = 'integration_test'
+  config['development'] ||= {}
+  config['development']['entries'] ||= {
+    'main' => 'src/index.tsx'
+  }
+end
+
+puts({ 'extensions' => [config] }.to_yaml)


### PR DESCRIPTION
[Issue #210](https://github.com/Shopify/shopify-cli-extensions/issues/210) - Remove entrypoint configuration requirement
* Remove 'development.entries' from extension config template
* Adjust integration test to provide defaults
* Refactor defaults into support/merge_config.rb