### PR TITLE
Renderer version

### DIFF
--- a/core/fsutils/fsutils.go
+++ b/core/fsutils/fsutils.go
@@ -91,6 +91,7 @@ func (fs *FS) MergeTemplateData(templateData interface{}, filePath string) (*byt
 	}
 
 	fileTemplate := template.New(filePath)
+	fileTemplate.Funcs(templateHelpers)
 	fileTemplate, err = fileTemplate.Parse(string(content))
 	if err != nil {
 		return &templateContent, err
@@ -148,4 +149,10 @@ type OnEachFile func(filePath string, targetPath string) error
 type FS struct {
 	*embed.FS
 	root string
+}
+
+var templateHelpers template.FuncMap = template.FuncMap{
+	"raw": func(value string) template.HTML {
+		return template.HTML(value)
+	},
 }

--- a/create/create.go
+++ b/create/create.go
@@ -358,12 +358,21 @@ func formatContent(targetPath string, content []byte) ([]byte, error) {
 	return content, nil
 }
 
-func formatJSON(bytes []byte) ([]byte, error) {
+func formatJSON(input []byte) ([]byte, error) {
 	var result map[string]interface{}
-	if err := json.Unmarshal(bytes, &result); err != nil {
+	if err := json.Unmarshal(input, &result); err != nil {
 		return nil, err
 	}
-	return json.MarshalIndent(result, "", "  ")
+
+	var output bytes.Buffer
+	encoder := json.NewEncoder(&output)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(result); err != nil {
+		return nil, err
+	}
+
+	return output.Bytes(), nil
 }
 
 func formatYaml(unformattedContent []byte, targetPath string) (content []byte, err error) {
@@ -447,6 +456,7 @@ var Command = func(dir, executable string, args ...string) (runner Runner) {
 
 type Runner interface {
 	Run() error
+	CombinedOutput() ([]byte, error)
 }
 
 func installDependencies(path string) process.Task {
@@ -458,21 +468,25 @@ func installDependencies(path string) process.Task {
 			} else if npm, err := LookPath("npm"); err == nil {
 				package_manager = npm
 			} else {
-				return errors.New("Package manager not found")
+				return errors.New("package manager not found")
 			}
 
-			err := Command(path, package_manager).Run()
+			cmd := Command(path, package_manager)
+			output, err := cmd.CombinedOutput()
+
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to install dependencies: %s", output)
 			}
 			return nil
 		},
 		Undo: func() error {
+			// TODO: Skip if directory doesn't exist
 			cmd := exec.Command("rm", "-rf", "node_modules")
 			cmd.Dir = path
 			if err := cmd.Run(); err != nil {
 				return err
 			}
+
 			return nil
 		},
 	}

--- a/create/create_test.go
+++ b/create/create_test.go
@@ -13,7 +13,9 @@ import (
 
 type dummyRunner struct{}
 
-func (r dummyRunner) Run() error { return nil }
+func (r dummyRunner) Run() error                      { return nil }
+func (r dummyRunner) CombinedOutput() ([]byte, error) { return []byte{}, nil }
+
 func makeDummyRunner(path, executable string, args ...string) Runner {
 	return dummyRunner{}
 }
@@ -95,7 +97,7 @@ func TestMergeTemplatesJSON(t *testing.T) {
 		Development: core.Development{
 			Template: "typescript-react",
 			RootDir:  rootDir,
-			Renderer: core.Renderer{Name: "@shopify/admin-ui-extension"},
+			Renderer: core.Renderer{Name: "@shopify/admin-ui-extension", Version: "latest"},
 		},
 	}
 
@@ -134,6 +136,7 @@ func TestMergeTemplatesJSON(t *testing.T) {
 		t.Errorf("expect \"@apollo/client\" dependency to match template config but received %v", config.Dependencies["@apollo/client"])
 	}
 
+	t.Log(config.Dependencies)
 	if config.Dependencies["@shopify/admin-ui-extension-react"] != "latest" {
 		t.Errorf("expect \"@shopify/admin-ui-extension-react\" dependency to match template config but received %v", config.Dependencies["@shopify/admin-ui-extension-react"])
 	}

--- a/create/templates/package.json.tpl
+++ b/create/templates/package.json.tpl
@@ -2,8 +2,8 @@
     "name": "{{ .Type }}",
     "license": "MIT",
     "dependencies": {
-      {{ if .React }}"{{ .Development.Renderer.Name }}-react": "latest",{{ end }}
-      {{ if .React }}"react": "^17.0.0"{{ else }}"{{ .Development.Renderer.Name }}": "latest"{{ end }}
+      {{ if .React }}"{{ .Development.Renderer.Name }}-react": "{{ raw .Development.Renderer.Version }}",{{ end }}
+      {{ if .React }}"react": "^17.0.0"{{ else }}"{{ .Development.Renderer.Name }}": "{{ raw .Development.Renderer.Version }}"{{ end }}
     },
     "devDependencies": {
       {{ if .TypeScript }}"typescript": "^4.1.0",{{ end }}
@@ -14,4 +14,3 @@
       "develop": "shopify-cli-extensions develop"
     }
   }
-  

--- a/testdata/extension.config.integration.yml
+++ b/testdata/extension.config.integration.yml
@@ -2,10 +2,11 @@ extensions:
   - uuid: 00000000-0000-0000-0000-000000000000
     type: integration_test
     development:
-      root_dir: "tmp/integration_test"
-      build_dir: "build"
-      template: "typescript-react"
+      root_dir: tmp/integration_test
+      build_dir: build
+      template: typescript-react
       renderer:
         name: "@shopify/checkout-ui-extensions"
+        version: ~> 0.14.0
       entries:
-        main: "src/index.tsx"
+        main: src/index.tsx

--- a/testdata/extension.config.yml
+++ b/testdata/extension.config.yml
@@ -17,6 +17,7 @@ extensions:
       template: 'typescript-react'
       renderer:
         name: '@shopify/checkout-ui-extensions'
+        version: '^0.14.0'
       entries:
         main: 'src/index.tsx'
       resource:
@@ -30,6 +31,7 @@ extensions:
       template: 'typescript-react'
       renderer:
         name: '@shopify/admin-ui-extensions'
+        version: '^1.0.1'
       entries:
         main: 'src/index.tsx'
   - uuid: 00000000-0000-0000-0000-000000000002
@@ -44,5 +46,6 @@ extensions:
       template: 'typescript-react'
       renderer:
         name: '@shopify/post-purchase-ui-extensions'
+        version: '^0.13.2'
       entries:
         main: 'src/index.tsx'


### PR DESCRIPTION
The renderer version is now configured via the extension configuration:

```
extensions[].Development.Renderer.Version
```

instead of being hardcoded to latest. The corresponding [PR in `Shopify/shopify-cli`](https://github.com/Shopify/shopify-cli/pull/2117) will ensure that a version is always passed down.
