### PR TITLE
Next Step Template for Post Purchase

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -252,19 +252,6 @@ func TestAdminRedirect(t *testing.T) {
 	}
 }
 
-func TestPostPurchaseIndex(t *testing.T) {
-	api := New(config, apiRoot)
-	response := getHTMLResponse(api, t, secureHost, "/extensions/00000000-0000-0000-0000-000000000002")
-
-	t.Logf("response: %s", response)
-
-	instructions := "Create a checkout and append <code>?dev=https://123.ngrok-url/extensions/00000000-0000-0000-0000-000000000002</code> to the URL to start developing your extension."
-
-	if !strings.Contains(response, instructions) {
-		t.Errorf("expected instructions to contain %s", instructions)
-	}
-}
-
 func TestWebsocketNotify(t *testing.T) {
 	api := New(config, apiRoot)
 	server := httptest.NewServer(api)

--- a/api/root/templates/checkout_post_purchase/index.html.tpl
+++ b/api/root/templates/checkout_post_purchase/index.html.tpl
@@ -35,7 +35,6 @@
   <body>
   <div class="content">
       <p>This page is served by your local UI Extension development server. Instead of visiting this page directly, you will need to connect your local development environment to a real checkout environment.</p>
-      <p>Create a checkout and append <code>?dev={{ .Development.Root.Url }}</code> to the URL to start developing your extension.</p>
   </div>
   </body>
 </html>

--- a/create/templates/checkout_post_purchase/next-steps.txt
+++ b/create/templates/checkout_post_purchase/next-steps.txt
@@ -5,7 +5,3 @@
 
 🔭 > Once installed, simply enter your extension URL
 🔭 > {{.IntegrationContext.PublicUrl}}/extensions/{{.Extension.UUID}}.
-
-🔭 > If you prefer to test your extension without using our browser extension,
-🔭 > create a checkout and append a query parameter to the checkout URL:
-🔭 > ?dev={{.IntegrationContext.PublicUrl}}/extensions/{{.Extension.UUID}}

--- a/create/templates/checkout_post_purchase/next-steps.txt
+++ b/create/templates/checkout_post_purchase/next-steps.txt
@@ -1,0 +1,11 @@
+
+🔭 > If this is the first time you're testing a Post Purchase extension,
+🔭 > please install the Chrome or Firefox browser extension from
+🔭 > https://github.com/Shopify/post-purchase-devtools/releases.
+
+🔭 > Once installed, simply enter your extension URL
+🔭 > {{.IntegrationContext.PublicUrl}}/extensions/{{.Extension.UUID}}.
+
+🔭 > If you prefer to test your extension without using our browser extension,
+🔭 > create a checkout and append a query parameter to the checkout URL:
+🔭 > ?dev={{.IntegrationContext.PublicUrl}}/extensions/{{.Extension.UUID}}


### PR DESCRIPTION
Resolution of issue #234 - Next Step Template for Post Purchase
```
Post Purchase Test Extension (Build succeeded)

🔭 > If this is the first time you're testing a Post Purchase extension,
🔭 > please install the Chrome or Firefox browser extension from
🔭 > https://github.com/Shopify/post-purchase-devtools/releases.

🔭 > Once installed, simply enter your extension URL
🔭 > https://example.ngrok.io/extensions/00000000-0000-0000-0000-000000000002.
```

