### PR TITLE
Expose locale data for checkout UI extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ integration-test: tmp build
 		ruby ../../support/merge_config.rb | \
 		../../shopify-extensions build -
 	test -f tmp/integration_test/build/main.js
+	test -f tmp/integration_test/locales/en.default.json
 
 .PHONY: update-version
 update-version:

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -100,6 +100,10 @@ func TestGetExtensions(t *testing.T) {
 	if api.Extensions[0].Development.Root.Url != "" || api.Extensions[0].Assets["main"].Url != "" {
 		t.Error("expect extension API data urls to not to be mutated")
 	}
+
+	if extension.Localization != nil {
+		t.Error("expect localization to be nil without defined locales")
+	}
 }
 
 func TestGetSingleExtension(t *testing.T) {
@@ -166,6 +170,11 @@ func TestGetSingleExtension(t *testing.T) {
 	if api.Extensions[0].Development.Root.Url != "" || api.Extensions[0].Assets["main"].Url != "" {
 		t.Error("expect extension API data urls to not to be mutated")
 	}
+
+	if extension.Localization != nil {
+		t.Error("expect localization to be nil without defined locales")
+	}
+
 }
 
 func TestServeAssets(t *testing.T) {
@@ -735,6 +744,7 @@ func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
 		  "uuid": "00000000-0000-0000-0000-000000000000",
 		  "version": "",
 		  "extensionPoints": null,
+		  "localization": null,
 		  "surface": "checkout"
 		}
 	  ]`, server.URL, server.URL)

--- a/core/core.go
+++ b/core/core.go
@@ -31,6 +31,7 @@ func NewExtensionService(config *Config, apiRoot string) *ExtensionService {
 			name := keys[entry]
 			extension.Assets[name] = Asset{Name: name}
 		}
+
 		extension.Surface = GetSurface(&extension)
 		extensions = append(extensions, extension)
 	}
@@ -62,15 +63,15 @@ type appYaml struct {
 }
 
 type Config struct {
-	App        appYaml     `yaml:"app"`
-	Extensions []Extension `yaml:"extensions"`
-	Port       int
+	App                appYaml     `yaml:"app"`
+	Extensions         []Extension `yaml:"extensions"`
+	Port               int
 	IntegrationContext `yaml:",inline"`
 }
 
 type IntegrationContext struct {
-	PublicUrl  string `yaml:"public_url"`
-	Store      string `yaml:"store"`
+	PublicUrl string `yaml:"public_url"`
+	Store     string `yaml:"store"`
 }
 
 type ExtensionService struct {
@@ -82,10 +83,16 @@ type ExtensionService struct {
 	PublicUrl  string
 }
 
+type Localization struct {
+	DefaultLocale string                 `json:"defaultLocale" yaml:"default_locale"`
+	Translations  map[string]interface{} `json:"translations" yaml:"translations"`
+}
+
 type Extension struct {
 	Assets          map[string]Asset `json:"assets" yaml:"-"`
 	Development     Development      `json:"development" yaml:"development,omitempty"`
 	ExtensionPoints []string         `json:"extensionPoints" yaml:"extension_points,omitempty"`
+	Localization    *Localization    `json:"localization" yaml:"-"`
 	Metafields      []Metafield      `json:"metafields" yaml:"metafields,omitempty"`
 	Type            string           `json:"type" yaml:"type,omitempty"`
 	UUID            string           `json:"uuid" yaml:"uuid,omitempty"`

--- a/core/fsutils/fsutils.go
+++ b/core/fsutils/fsutils.go
@@ -66,7 +66,7 @@ func (fs *FS) Execute(op *Operation) (err error) {
 
 			if err = fs.Execute(&Operation{
 				SourceDir:  relativeDir,
-				TargetDir:  op.TargetDir,
+				TargetDir:  filepath.Join(op.TargetDir, fileName),
 				OnEachFile: op.OnEachFile,
 			}); err != nil {
 				return

--- a/create/create.go
+++ b/create/create.go
@@ -32,7 +32,7 @@ const (
 )
 
 func ReadTemplateFile(path string) ([]byte, error) {
-    return templates.ReadFile(path)
+	return templates.ReadFile(path)
 }
 
 func NewExtensionProject(extension core.Extension) (err error) {
@@ -205,6 +205,11 @@ func mergeYamlAndJsonFiles(fs *fsutils.FS, project *project) process.Task {
 				OnEachFile: func(filePath, targetPath string) (err error) {
 					if !strings.HasSuffix(targetPath, fsutils.JSON) && !strings.HasSuffix(targetPath, fsutils.YAML) {
 						return
+					}
+
+					err = os.MkdirAll(filepath.Dir(targetPath), os.ModePerm)
+					if err != nil {
+						return err
 					}
 
 					targetFile, openErr := fsutils.OpenFileForAppend(targetPath)

--- a/create/create_test.go
+++ b/create/create_test.go
@@ -316,3 +316,38 @@ func TestInstallDependencies(t *testing.T) {
 		os.RemoveAll(rootDir)
 	})
 }
+
+func TestCreateLocaleFiles(t *testing.T) {
+	Command = makeDummyRunner
+	LookPath = func(file string) (string, error) {
+		return file, nil
+	}
+	rootDir := "tmp/TestCreateLocalesFiles"
+	extension := core.Extension{
+		Type: "integration_test",
+		Development: core.Development{
+			Template: "typescript-react",
+			RootDir:  rootDir,
+			Renderer: core.Renderer{Name: "@shopify/checkout_ui_extension"},
+		},
+	}
+
+	err := NewExtensionProject(extension)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := os.ReadDir(fmt.Sprintf("%s/locales", rootDir))
+	if err != nil {
+		t.Error("expect a \"/locales\" directory to exist")
+	}
+
+	if len(files) == 0 {
+		t.Error("expect the locales directory to have locale files")
+	}
+
+	t.Cleanup(func() {
+		os.RemoveAll(rootDir)
+	})
+}

--- a/create/templates/checkout_ui_extension/javascript.js
+++ b/create/templates/checkout_ui_extension/javascript.js
@@ -1,11 +1,11 @@
 import { extend, Text } from "@shopify/checkout-ui-extensions";
 
-extend("Checkout::Feature::Render", (root, { extensionPoint }) => {
+extend("Checkout::Feature::Render", (root, { extensionPoint, i18n }) => {
   root.appendChild(
     root.createComponent(
       Text,
       {},
-      `Welcome to the ${extensionPoint} extension!`
+      i18n.translate('welcome', {extensionPoint})
     )
   );
   root.mount();

--- a/create/templates/checkout_ui_extension/locales/en.default.json
+++ b/create/templates/checkout_ui_extension/locales/en.default.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Welcome to the {{extensionPoint}} extension!"
+}

--- a/create/templates/checkout_ui_extension/locales/fr.json
+++ b/create/templates/checkout_ui_extension/locales/fr.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Bienvenue dans l'extension {{extensionPoint}}!"
+}

--- a/create/templates/checkout_ui_extension/react.js
+++ b/create/templates/checkout_ui_extension/react.js
@@ -3,6 +3,6 @@ import {render, Text} from '@shopify/checkout-ui-extensions-react';
 
 render('Checkout::Feature::Render', App);
 
-function App({extensionPoint}) {
-  return <Text>Welcome to the {extensionPoint} extension!</Text>;
+function App({extensionPoint, i18n}) {
+  return <Text>{i18n.translate('welcome', {extensionPoint})}</Text>;
 }

--- a/create/templates/integration_test/locales/en.default.json
+++ b/create/templates/integration_test/locales/en.default.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Welcome to the {{extensionPoint}} extension!"
+}

--- a/create/templates/integration_test/locales/fr.json
+++ b/create/templates/integration_test/locales/fr.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Bienvenue dans l'extension {{extensionPoint}}!"
+}


### PR DESCRIPTION
This fixes https://github.com/Shopify/checkout-web/issues/8567 by exposing translations in the [`shopify extension serve`](https://shopify.dev/apps/tools/cli/extension-commands#serve) API. This enables developers to preview their extension in [checkout](https://checkout.docs.shopify.io/), as [designed](https://docs.google.com/document/d/1Qg9AGnkSLGx10zetJIrLfzvt554_AKb7HykUK5y1_mA/edit#heading=h.v761dn5at450).

If a `locales` directory exists, the server will parse each JSON file and combine them into a `localizations` property.

<details>
<summary>Example response</summary>

_Some properties are omitted for brevity_

```json
{
  "extensions": [
    {
      "assets": {
        "main": {
          "name": "main",
          "url": "https://7cbc-2600-1700-5658-3c50-fdd0-8885-93fc-9d51.ngrok.io/extensions/00000000-0000-0000-0000-000000000000/assets/main.js",
          "lastUpdated": 1647632788
        }
      },
      "development": {
        "resource": {
          "url": "cart/1234"
        },
        "root": {
          "url": "https://7cbc-2600-1700-5658-3c50-fdd0-8885-93fc-9d51.ngrok.io/extensions/00000000-0000-0000-0000-000000000000"
        }
      },
      "extensionPoints": ["Checkout::Feature::Render"],
      "localization": {
        "defaultLocale": "en",
        "translations": {
          "en": {
            "welcome": "Welcome to the {{extensionPoint}} extension!"
          },
          "fr": {
            "welcome": "Bienvenue dans l'extension {{extensionPoint}}!"
          }
        }
      },
      "metafields": [],
      "type": "checkout_ui_extension",
      "uuid": "00000000-0000-0000-0000-000000000000",
      "version": "",
      "surface": "checkout",
      "title": "Checkout UI Test Extension"
    }
  ]
}
```

</details>


## 🎩 

<details>
<summary>Complete tophatting instructions</summary>

### Getting started


This cannot be tophatted entirely in Spin so we'll use Spin for the Shopify + Checkout constallation and our local machine for everything else.


Create a Spin workspace:
```
spin up checkout-web,online-store-web --name cli-locales
```

### Local setup


While that's booting, set up your local machine.


In a _local_ shell, get the `shopify-cli-extensions` patch, and expose its package for linking:

```
dev clone shopify-cli-extensions
gh pr checkout https://github.com/Shopify/shopify-cli-extensions/pull/237
dev up
make bootstrap
cd packages/shopify-cli-extensions
yarn link
```

In a _local_ shell, get a [`shopify-cli`](https://github.com/Shopify/shopify-cli) patch (this is [temporary](https://github.com/Shopify/shopify-cli/tree/kumar-locales)), and symlink `shopify-cli-extensions`:

```
dev clone shopify-cli
git checkout kumar-locales
bundle install
rake extensions:symlink
```


In a _local_ shell, make sure `checkout-web` is up to date (just for linking purposes):
```
dev clone checkout-web
git pull
dev up
```


In a _local_ shell, get a reference extension from [`checkout-ui-extension-dev`](https://github.com/Shopify/checkout-ui-extension-dev), and link it to `shopify-cli-extensions`:
```
dev clone checkout-ui-extension-dev
git checkout new-cli
dev up
yarn link "@shopify/shopify-cli-extensions"
```

If you don't have `ngrok` configured, get a [token](https://dashboard.ngrok.com/get-started/your-authtoken) and add it to your local machine:

```
ngrok authtoken [the token string]
```

The `checkout-ui-extension-dev` repo provides `yarn shopify`, an alias to your local `shopify-cli` executable.

Make sure you are logged in to a development store (in _production_) that's [configured for extension development](https://checkout--add-extensions-spin-quick-star.docs.shopify.io/docs/referencedocs/web/extensions/development#standalone-extension) to work around [this bug](https://github.com/Shopify/shopify-cli/issues/1604). Example:

```
yarn shopify logout
yarn shopify login --store=https://your-dev-store.myshopify.com/
```

Select an [extension you use for development](https://checkout--add-extensions-spin-quick-star.docs.shopify.io/docs/referencedocs/web/extensions/development#standalone-extension).
```
yarn shopify extension connect
```

Run `shopify extension serve` using an alias:
```
yarn start
```

The output should end with something like:
```
┏━━ Serving extension… ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ DEBUG Sending configuration data to extension development server …
┃ DEBUG Starting message processing threads to relay output produced by the extension development server …
┃ Shopify CLI Extensions Server is now available at https://c52a-2600-1700-5658-3c50-11e0-9470-dd4c-d96e.ngrok.io
┃ preload-extension-installed (Build succeeded)
```

Set your ngrok extension URL:
```
EXT_HOST=https://c52a-2600-1700-5658-3c50-11e0-9470-dd4c-d96e.ngrok.io
```

Preview the API response using [`jq`](https://stedolan.github.io/jq/) (optional):

```
curl ${EXT_HOST}/extensions/ | jq .
```

### Checkout

Phew! You made it. Start a checkout running in Spin _connected_ to your locally running extension:

```
open "https://shop1.shopify.$(spin show -o fqdn)/cart/1:1?dev=${EXT_HOST}/extensions/"
```

The extension should show some translated content like this:


<img width="1057" alt="Screen Shot 2022-03-22 at 10 58 11 AM" src="https://user-images.githubusercontent.com/55398/159532333-47981f5a-ef01-427a-8847-3c2bdcef8470.png">

</details>

## Questions for Reviewers
1. **Will these changes be a good foundation for (future) implementing hot-reload for refresh of locales as they change in the extension?**
Localization/Translations are now being generated at runtime and are processed and returned in the `HTTP GET /extensions/ ` method. They are also being processed when hot module reloads are occurring (this currently has no effect in refreshing the locales though in the extension itself). We followed the existing paradigm where `extension.Assets` where being processed in the same fashion. When we implement hot module reloading in the future, will we be relying on the websocket to restart the sandbox and refresh the locales being used in the extension, or make the extension re-fetch `HTTP GET /extensions` method?

2. **Feedback on test strategy for returning Localization/Translations from filesystem**
There doesn't appear to be a great way to test this based off of actual filesystem locale files, unless i'm mistaken. So far, we've only implemented basic tests where `Localization` should be nil when there are no locales.

3. **If there is an error processing Localization/Translations from the filesystem, how should we report this to the user?** Currently, we `log` the error using `log.Printf()`.
