### PR TITLE
Avoid yarn errors for Shopify employees by supporting dev up

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,26 @@ The information below is mainly targeting contributors rather than users. If you
 
 ## Getting started
 
+Prerequisites:
+
+- [Go](https://go.dev/), version 1.17 or higher
+- The current [LTS version](https://nodejs.org/en/about/releases/) of [Node.JS](https://nodejs.org/en/)
+
 Install Go by running
 
 ```sh
 brew install go
 ```
 
-and familiarize yourself with the `Makefile`. It defines several useful tasks for building and testing the project.
+Install Node.JS by running:
+
+```sh
+brew install node
+```
+
+> **OPTIONAL**: If you are a Shopify employee, your machine may be configured to use `npm.shopify.io`. To avoid `yarn` errors, install the project by running `dev up`.
+
+Next, familiarize yourself with the `Makefile`. It defines several useful tasks for building and testing the project.
 
 To build the project, bootstrap some example extensions and install all of their dependencies, run:
 

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,11 @@
+name: shopify-cli-extensions
+
+type: go
+
+up:
+  - node:
+      version: v16.13.1
+      yarn: v1.22.17
+  - go:
+      version: 1.17.6
+      modules: true


### PR DESCRIPTION
What do you think about supporting `dev up`?

I hit an error in `make bootstrap` which was actually a problem running `yarn install` inside `tmp/checkout_ui_extension`:

<img width="925" alt="Screen Shot 2022-03-08 at 4 31 23 PM" src="https://user-images.githubusercontent.com/55398/157339137-da0a74db-6bce-44b4-a634-e7874defc6d9.png">

`dev up` fixes it automatically, probably via `shadowenv`:

<img width="280" alt="Screen Shot 2022-03-08 at 4 24 17 PM" src="https://user-images.githubusercontent.com/55398/157339169-a6ce0584-f109-4501-8663-3a5a196ca489.png">

I added an explanation to the readme of why this is needed but I'm not totally sure it's accurate 😅 
