### PR TITLE
Make post purchase extension links functional

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -256,18 +256,18 @@ func TestPostPurchaseIndex(t *testing.T) {
 	api := New(config, apiRoot)
 	response := getHTMLResponse(api, t, secureHost, "/extensions/00000000-0000-0000-0000-000000000002")
 
-	staticContent := "This page is served by your local UI Extension development server. " + 
-	"Instead of visiting this page directly, you will need to connect your local development environment to a real checkout environment."
-	dynamicContent := "If this is the first time you're testing a Post Purchase extension, please install the Chrome or Firefox browser extension from https://github.com/Shopify/post-purchase-devtools/releases. " +
-	"Once installed, simply enter your extension URL https://example.ngrok.io/extensions/00000000-0000-0000-0000-000000000002."
+	contents := [...]string{
+		"This page is served by your local UI Extension development server. Instead of visiting this page directly, you will need to connect your local development environment to a real checkout environment.",
+		"If this is the first time you're testing a Post Purchase extension, please install the browser extension from <a href=\"https://github.com/Shopify/post-purchase-devtools/releases\">https://github.com/Shopify/post-purchase-devtools/releases</a>.",
+		"Once installed, simply enter your extension URL <a href=\"https://example.ngrok.io/extensions/00000000-0000-0000-0000-000000000002\">https://example.ngrok.io/extensions/00000000-0000-0000-0000-000000000002</a>.",
+	}
 
 	t.Logf("response: %s", response)
 
-	if !strings.Contains(response, staticContent) {
-	 	t.Errorf(`expected instructions to contain "%s"`, staticContent)
-	}
-	if !strings.Contains(response, dynamicContent) {
-	 	t.Errorf(`expected instructions to contain "%s"`, dynamicContent)
+	for _, line := range contents {
+		if !strings.Contains(response, line) {
+			t.Errorf(`expected instructions to contain "%s"`, line)
+		}
 	}
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -264,10 +264,14 @@ func TestPostPurchaseIndex(t *testing.T) {
 
 	t.Logf("response: %s", response)
 
-	for _, line := range contents {
-		if !strings.Contains(response, line) {
-			t.Errorf(`expected instructions to contain "%s"`, line)
-		}
+	if !strings.Contains(response, contents[0]) {
+		t.Errorf(`expected instructions to contain "%s"`, contents[0])
+	}
+	if !strings.Contains(response, contents[1]) {
+		t.Errorf(`expected instructions to contain "%s"`, contents[1])
+	}
+	if !strings.Contains(response, contents[2]) {
+		t.Errorf(`expected instructions to contain "%s"`, contents[2])
 	}
 }
 

--- a/api/root/templates/checkout_post_purchase/index.html.tpl
+++ b/api/root/templates/checkout_post_purchase/index.html.tpl
@@ -36,7 +36,7 @@
   <div class="content">
       <p>This page is served by your local UI Extension development server. Instead of visiting this page directly, you will need to connect your local development environment to a real checkout environment.<br>
       <br> 
-      If this is the first time you're testing a Post Purchase extension, please install the Chrome or Firefox browser extension from <a href="https://github.com/Shopify/post-purchase-devtools/releases">https://github.com/Shopify/post-purchase-devtools/releases</a>.<br>
+      If this is the first time you're testing a Post Purchase extension, please install the browser extension from <a href="https://github.com/Shopify/post-purchase-devtools/releases">https://github.com/Shopify/post-purchase-devtools/releases</a>.<br>
       <br>
       Once installed, simply enter your extension URL <a href="{{.PublicUrl}}/extensions/{{.UUID}}">{{.PublicUrl}}/extensions/{{.UUID}}</a>.</p>
   </div>

--- a/api/root/templates/checkout_post_purchase/index.html.tpl
+++ b/api/root/templates/checkout_post_purchase/index.html.tpl
@@ -36,7 +36,9 @@
   <div class="content">
       <p>This page is served by your local UI Extension development server. Instead of visiting this page directly, you will need to connect your local development environment to a real checkout environment.<br>
       <br> 
-      If this is the first time you're testing a Post Purchase extension, please install the Chrome or Firefox browser extension from https://github.com/Shopify/post-purchase-devtools/releases. Once installed, simply enter your extension URL {{.PublicUrl}}/extensions/{{.UUID}}.</p>
+      If this is the first time you're testing a Post Purchase extension, please install the Chrome or Firefox browser extension from <a href="https://github.com/Shopify/post-purchase-devtools/releases">https://github.com/Shopify/post-purchase-devtools/releases</a>.<br>
+      <br>
+      Once installed, simply enter your extension URL <a href="{{.PublicUrl}}/extensions/{{.UUID}}">{{.PublicUrl}}/extensions/{{.UUID}}</a>.</p>
   </div>
   </body>
 </html>

--- a/create/templates/checkout_post_purchase/next-steps.txt
+++ b/create/templates/checkout_post_purchase/next-steps.txt
@@ -1,7 +1,6 @@
 
-🔭 > If this is the first time you're testing a Post Purchase extension,
-🔭 > please install the Chrome or Firefox browser extension from
-🔭 > https://github.com/Shopify/post-purchase-devtools/releases.
+🔭 > If this is the first time you're testing a Post Purchase extension, please install
+🔭 > the browser extension from https://github.com/Shopify/post-purchase-devtools/releases.
 
 🔭 > Once installed, simply enter your extension URL
 🔭 > {{.IntegrationContext.PublicUrl}}/extensions/{{.Extension.UUID}}.


### PR DESCRIPTION
Use anchor tags in index.html.tpl to make post purchase links functional.

<img width="591" alt="Screen Shot 2022-03-11 at 4 31 41 PM" src="https://user-images.githubusercontent.com/4490738/157973336-2e37bf5a-f2b6-4c7a-a87b-bb2c215d370d.png">

