### PR TITLE
Cache-Control: no-cache & Temporary Redirects

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -252,7 +252,7 @@ func configureExtensionsApi(config *core.Config, router *mux.Router, apiRoot str
 		assets := path.Join(apiRoot, extension.UUID, "assets")
 		buildDir := filepath.Join(".", extension.Development.RootDir, extension.Development.BuildDir)
 		api.PathPrefix(assets).Handler(
-			withCors(http.StripPrefix(assets, http.FileServer(http.Dir(buildDir)))),
+			withoutCache(withCors(http.StripPrefix(assets, http.FileServer(http.Dir(buildDir))))),
 		)
 	}
 
@@ -503,6 +503,13 @@ func withCors(h http.Handler) http.HandlerFunc {
 		rw.Header().Set("Access-Control-Allow-Origin", "*")
 		rw.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
 		rw.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+		h.ServeHTTP(rw, r)
+	}
+}
+
+func withoutCache(h http.Handler) http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Cache-Control", "no-cache")
 		h.ServeHTTP(rw, r)
 	}
 }

--- a/api/api.go
+++ b/api/api.go
@@ -34,7 +34,7 @@ func New(config *core.Config, apiRoot string) *ExtensionsApi {
 	mux := mux.NewRouter()
 
 	mux.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
-		http.Redirect(rw, r, "/dev-console", http.StatusPermanentRedirect)
+		http.Redirect(rw, r, "/dev-console", http.StatusTemporaryRedirect)
 	})
 
 	api := configureExtensionsApi(config, mux, apiRoot)
@@ -261,7 +261,7 @@ func configureExtensionsApi(config *core.Config, router *mux.Router, apiRoot str
 	api.PathPrefix("/dev-console").Handler(http.FileServer(http.FS(devConsole)))
 
 	api.PathPrefix("/assets/").Handler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		http.Redirect(rw, r, path.Join("/dev-console", r.URL.Path), http.StatusPermanentRedirect)
+		http.Redirect(rw, r, path.Join("/dev-console", r.URL.Path), http.StatusTemporaryRedirect)
 	}))
 
 	return api

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -170,9 +170,20 @@ func TestGetSingleExtension(t *testing.T) {
 
 func TestServeAssets(t *testing.T) {
 	api := New(config, apiRoot)
-	response := getHTMLResponse(api, t, localhost, "/extensions/00000000-0000-0000-0000-000000000000/assets/main.js")
+	response := getHTMLRequest(api, t, localhost, "/extensions/00000000-0000-0000-0000-000000000000/assets/main.js")
 
-	if response != "console.log(\"Hello World!\");\n" {
+	if response.Result().StatusCode != http.StatusOK {
+		t.Error("expected status code ok received")
+	}
+
+	cachePolicy := response.Result().Header["Cache-Control"]
+	if len(cachePolicy) == 0 {
+		t.Error("expected server to specify a cache policy")
+	} else if cachePolicy[0] != "no-cache" {
+		t.Errorf("expected cache policy to be no-cache not %s", cachePolicy[0])
+	}
+
+	if response.Body.String() != "console.log(\"Hello World!\");\n" {
 		t.Error("Unexpected body")
 	}
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -234,7 +234,7 @@ func TestCheckoutRedirect(t *testing.T) {
 	api := New(config, apiRoot)
 	rec := getHTMLRequest(api, t, secureHost, "/extensions/00000000-0000-0000-0000-000000000000")
 
-	if rec.Code != http.StatusPermanentRedirect {
+	if rec.Code != http.StatusTemporaryRedirect {
 		t.Errorf("expected redirect status – received: %d", rec.Code)
 	}
 
@@ -251,7 +251,7 @@ func TestAdminRedirect(t *testing.T) {
 	api := New(config, apiRoot)
 	rec := getHTMLRequest(api, t, secureHost, "/extensions/00000000-0000-0000-0000-000000000001")
 
-	if rec.Code != http.StatusPermanentRedirect {
+	if rec.Code != http.StatusTemporaryRedirect {
 		t.Errorf("Expected redirect status – received: %d", rec.Code)
 	}
 

--- a/api/root/root.go
+++ b/api/root/root.go
@@ -61,7 +61,7 @@ func (root *RootHandler) HandleHTMLRequest(rw http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	http.Redirect(rw, r, url, http.StatusPermanentRedirect)
+	http.Redirect(rw, r, url, http.StatusTemporaryRedirect)
 }
 
 func IsSecureRequest(r *http.Request) bool {

--- a/api/root/root.go
+++ b/api/root/root.go
@@ -20,9 +20,9 @@ func New(config *core.Config, apiRoot string) *RootHandler {
 	return &RootHandler{
 		fsutils.NewFS(&templates, "templates"),
 		&apiConfig{
-			ApiRoot: apiRoot,
-			Port:    config.Port,
-			Store:   config.Store,
+			ApiRoot:            apiRoot,
+			Port:               config.Port,
+			Store:              config.Store,
 			IntegrationContext: config.IntegrationContext,
 		},
 	}


### PR DESCRIPTION
Changes:

* Sets `Cache-Control` header to `no-cache` for all static assets served by our fileserver
* Changes the permanent redirects to temporary ones to disable browser caching

Both changes seek to address weird browser caching behaviour that @vividviolet and I observed during testing.