### PR TITLE
Fix embedded file system access on Windows

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,7 +18,10 @@ jobs:
         run: make test
 
   integration-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -26,9 +29,9 @@ jobs:
           go-version: 1.17
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: '16'
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: "2.7"
+          ruby-version: '2.7'
       - name: Integration Test
         run: make integration-test

--- a/core/fsutils/fsutils.go
+++ b/core/fsutils/fsutils.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -131,10 +132,13 @@ func OpenFileForAppend(filePath string) (*os.File, error) {
 }
 
 func (fs *FS) normalizePath(filePath string) string {
-	if strings.HasPrefix(filePath, fs.root+"/") {
-		return filePath
+	pathComponents := strings.Split(filePath, string(os.PathSeparator))
+
+	if pathComponents[0] == fs.root {
+		return path.Join(pathComponents...)
+	} else {
+		return path.Join(append([]string{fs.root}, pathComponents...)...)
 	}
-	return filepath.Join(fs.root, filePath)
 }
 
 type Operation struct {

--- a/create/create.go
+++ b/create/create.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -32,7 +33,7 @@ const (
 )
 
 func ReadTemplateFile(path string) ([]byte, error) {
-    return templates.ReadFile(path)
+	return templates.ReadFile(path)
 }
 
 func NewExtensionProject(extension core.Extension) (err error) {
@@ -105,7 +106,7 @@ func createSourceFiles(fs *fsutils.FS, project *project) process.Task {
 				}
 			} else {
 				// Create main index file
-				err = fs.CopyFile(filepath.Join(project.Type, getMainTemplate(project)),
+				err = fs.CopyFile(path.Join(project.Type, getMainTemplate(project)),
 					filepath.Join(project.Development.RootDir, project.Development.Entries["main"]),
 				)
 


### PR DESCRIPTION
* Changes Github Action configuration to run the integration test on Windows, too.
* Fixes the path construction for paths referencing files in  the embedded filesystem. Go's embedded filesystem requires the use of forward slashes regardless of the platform that the Go application is being excuted on. Hence, there are a few places were we needed to replace `filepath.Join` with `path.Join` as the former uses OS specific path separators whereas the later always uses forward slashes.
