### PR TITLE
Make Python a project dependency

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,9 +3,11 @@ name: shopify-cli-extensions
 type: go
 
 up:
-  - node:
-      version: v16.13.1
-      yarn: v1.22.17
+  - python:
+      version: '3.9.10'
   - go:
       version: 1.17.6
       modules: true
+  - node:
+      version: v16.13.1
+      yarn: v1.22.17


### PR DESCRIPTION
Python 2.7 was removed with OS X 12.3 which can break the installation of node packages with native extensions as node-gyp relies on python being present.

This PR makes Python an official dependency to ensure that yarn install functions as expected.

To test this PR run

```sh
$ make clobber
$ dev up
```

If it exits cleanly and a node_modules folder has been produced, all is good.