### PR TITLE
Add localization file watcher

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -174,7 +174,6 @@ func TestGetSingleExtension(t *testing.T) {
 	if extension.Localization != nil {
 		t.Error("expect localization to be nil without defined locales")
 	}
-
 }
 
 func TestServeAssets(t *testing.T) {
@@ -736,6 +735,7 @@ func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
 			"hidden": false,
 			"resource": {"url": ""},
 			"root": {"url": "%v/extensions/00000000-0000-0000-0000-000000000000"},
+			"localizationStatus": "",
 			"status": "success",
 			"resource": {"url": "cart/1234"}
 			},

--- a/build/build.go
+++ b/build/build.go
@@ -2,15 +2,20 @@ package build
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 
+	"github.com/Shopify/shopify-cli-extensions/api"
 	"github.com/Shopify/shopify-cli-extensions/core"
 	"github.com/Shopify/shopify-cli-extensions/create"
+	"github.com/fsnotify/fsnotify"
 	"gopkg.in/yaml.v3"
 
 	"text/template"
@@ -65,7 +70,7 @@ func Watch(extension core.Extension, integrationCtx core.IntegrationContext, rep
 	logProcessors.Add(2)
 
 	templateBytes, _ := create.ReadTemplateFile(fmt.Sprintf(nextStepsTemplatePath, strings.ToLower(extension.Type)))
-	
+
 	go processLogs(stdout, logProcessingHandlers{
 		onCompletion: func() { logProcessors.Done() },
 		onMessage: func(message string) {
@@ -94,7 +99,7 @@ func Watch(extension core.Extension, integrationCtx core.IntegrationContext, rep
 
 // Builds 'Next Steps'
 func generateNextSteps(rawTemplate string, ext core.Extension, ctx core.IntegrationContext) string {
-	type contextRoot struct { 	// Wraps top-level elements, allowing them to be referenced in next-steps.txt
+	type contextRoot struct { // Wraps top-level elements, allowing them to be referenced in next-steps.txt
 		core.Extension
 		core.IntegrationContext
 	}
@@ -104,7 +109,7 @@ func generateNextSteps(rawTemplate string, ext core.Extension, ctx core.Integrat
 	templ := template.New("templ")
 	templ, err := templ.Parse(rawTemplate)
 	if err == nil {
-		contextRoot := contextRoot{ ext, ctx }
+		contextRoot := contextRoot{ext, ctx}
 		templ.Execute(&buf, contextRoot)
 	}
 
@@ -129,3 +134,125 @@ func configureScript(script *exec.Cmd, extension core.Extension) error {
 }
 
 const rwxr_xr_x = 0755
+
+func getLocalization(extension *core.Extension) (*core.Localization, error) {
+	path := filepath.Join(".", extension.Development.RootDir, "locales")
+	emptyResponse := &core.Localization{
+		DefaultLocale: "",
+		Translations:  make(map[string]interface{}),
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		// The extension does not have a locales directory.
+		return emptyResponse, nil
+	}
+
+	fileNames, err := api.GetFileNames(path)
+	if err != nil {
+		return emptyResponse, err
+	}
+	translations := make(map[string]interface{})
+	defaultLocale := ""
+	defaultLocalesFound := []string{}
+
+	for _, fileName := range fileNames {
+		data, err := api.GetMapFromJsonFile(filepath.Join(path, fileName))
+		if err != nil {
+			return emptyResponse, err
+		}
+
+		locale := strings.Split(fileName, ".")[0]
+
+		if api.IsDefaultLocale(fileName) {
+			defaultLocalesFound = append(defaultLocalesFound, locale)
+		}
+
+		translations[locale] = data
+	}
+
+	if len(translations) == 0 {
+		return emptyResponse, nil
+	} else {
+
+		if len(defaultLocalesFound) == 0 {
+			log.Println("could not determine a default locale, please ensure you have a {locale}.default.json file")
+		} else {
+			if len(defaultLocalesFound) > 1 {
+				log.Println("multiple default locales found, please ensure you only have a single {locale}.default.json file")
+			}
+			defaultLocale = defaultLocalesFound[0]
+		}
+
+		return &core.Localization{
+			DefaultLocale: defaultLocale,
+			Translations:  translations,
+		}, nil
+	}
+}
+
+func setLocalization(extension *core.Extension) error {
+	localization, err := getLocalization(extension)
+
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+	extension.Localization = localization
+	return nil
+}
+
+func WatchLocalization(ctx context.Context, extension core.Extension, report ResultHandler) {
+	directory := filepath.Join(".", extension.Development.RootDir, "locales")
+	if _, err := os.Stat(directory); os.IsNotExist(err) {
+		// The extension does not have a locales directory.
+		return
+	}
+
+	err := setLocalization(&extension)
+	if err != nil {
+		report(Result{false, err.Error(), extension})
+	}
+	report(Result{true, "successfully built localization", extension})
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer watcher.Close()
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+
+				triggers := map[string]bool{
+					fsnotify.Create.String(): true,
+					fsnotify.Rename.String(): true,
+					fsnotify.Write.String():  true,
+				}
+
+				if triggers[event.Op.String()] {
+					err := setLocalization(&extension)
+					if err != nil {
+						report(Result{false, fmt.Sprintf("could not resolve localization, error: %s\n", err.Error()), extension})
+					}
+					report(Result{true, "successfully built localization", extension})
+				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				log.Println("error:", err)
+			}
+		}
+	}()
+
+	err = watcher.Add(directory)
+	log.Println("Watcher added for:", directory)
+	if err != nil {
+		log.Fatal(err)
+	}
+	<-ctx.Done()
+}

--- a/core/core.go
+++ b/core/core.go
@@ -86,6 +86,7 @@ type ExtensionService struct {
 type Localization struct {
 	DefaultLocale string                 `json:"defaultLocale" yaml:"default_locale"`
 	Translations  map[string]interface{} `json:"translations" yaml:"translations"`
+	LastUpdated   int64                  `json:"lastUpdated" yaml:"lastUpdated"`
 }
 
 type Capabilities struct {
@@ -132,17 +133,18 @@ type commandConfig struct {
 }
 
 type Development struct {
-	Build    commandConfig     `json:"-" yaml:"build,omitempty"`
-	BuildDir string            `json:"-" yaml:"build_dir,omitempty"`
-	Develop  commandConfig     `json:"-" yaml:"develop,omitempty"`
-	Entries  map[string]string `json:"-" yaml:"entries,omitempty"`
-	Resource Url               `json:"resource" yaml:"resource,omitempty"`
-	Renderer Renderer          `json:"-" yaml:"renderer,omitempty"`
-	Root     Url               `json:"root" yaml:"root,omitempty"`
-	RootDir  string            `json:"-" yaml:"root_dir,omitempty"`
-	Hidden   bool              `json:"hidden" yaml:"-"`
-	Status   string            `json:"status" yaml:"-"`
-	Template string            `json:"-" yaml:"template,omitempty"`
+	Build              commandConfig     `json:"-" yaml:"build,omitempty"`
+	BuildDir           string            `json:"-" yaml:"build_dir,omitempty"`
+	Develop            commandConfig     `json:"-" yaml:"develop,omitempty"`
+	Entries            map[string]string `json:"-" yaml:"entries,omitempty"`
+	Resource           Url               `json:"resource" yaml:"resource,omitempty"`
+	Renderer           Renderer          `json:"-" yaml:"renderer,omitempty"`
+	Root               Url               `json:"root" yaml:"root,omitempty"`
+	RootDir            string            `json:"-" yaml:"root_dir,omitempty"`
+	Hidden             bool              `json:"hidden" yaml:"-"`
+	Status             string            `json:"status" yaml:"-"`
+	LocalizationStatus string            `json:"localizationStatus" yaml:"-"`
+	Template           string            `json:"-" yaml:"template,omitempty"`
 }
 
 func (d Development) UsesReact() bool {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Shopify/shopify-cli-extensions
 go 1.16
 
 require (
-	github.com/fsnotify/fsnotify v1.5.0
+	github.com/fsnotify/fsnotify v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/iancoleman/strcase v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/fsnotify/fsnotify v1.5.0 h1:NO5hkcB+srp1x6QmwvNZLeaOgbM8cmBTN32THzjvu2k=
 github.com/fsnotify/fsnotify v1.5.0/go.mod h1:BX0DCEr5pT4jm2CnQdVP1lFV521fcCNcyEeNp4DQQDk=
+github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
+github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/Shopify/shopify-cli-extensions/api"
 	"github.com/Shopify/shopify-cli-extensions/build"
@@ -106,6 +107,20 @@ func (cli *CLI) serve(args ...string) {
 			}
 
 			api.Notify([]core.Extension{extension})
+		})
+
+		go build.WatchLocalization(ctx, extension, func(result build.Result) {
+			extension := result.Extension
+
+			if result.Success {
+				extension.Localization.LastUpdated = time.Now().Unix()
+				extension.Development.LocalizationStatus = "success"
+				api.Notify([]core.Extension{extension})
+				fmt.Println(result)
+			} else {
+				extension.Development.LocalizationStatus = "error"
+				fmt.Fprintln(os.Stderr, result)
+			}
 		})
 	}
 


### PR DESCRIPTION
### What problem are you trying to solve?
Closes https://github.com/Shopify/checkout-web/issues/9581.
Necessary for https://github.com/Shopify/checkout-web/issues/9365.

This is a clean slate branch for [this older draft pull request](https://github.com/Shopify/shopify-cli-extensions/pull/260)

This is a follow-up [PR](https://github.com/Shopify/shopify-cli-extensions/pull/237) which will move where `extension.Localization` is being processed from happening at runtime for `HTTP GET /extensions/`, to a new watcher: `build.WatchLocalization`.

The goal of this PR is to increase performance by moving the processing of locales (which requires fs i/o) to the offline build watcher which will only re-process localization if the locale files have changed.

The `localization` property for an extension in the `HTTP GET /extensions/` response should remain the same. When a locale file is changed, it should also notify websocket subscribers of the change.

<details>
<summary>Example response</summary>

_Some properties are omitted for brevity_

```json
{
  "extensions": [
    {
      "assets": {
        "main": {
          "name": "main",
          "url": "https://7cbc-2600-1700-5658-3c50-fdd0-8885-93fc-9d51.ngrok.io/extensions/00000000-0000-0000-0000-000000000000/assets/main.js",
          "lastUpdated": 1647632788
        }
      },
      "development": {
        "resource": {
          "url": "cart/1234"
        },
        "root": {
          "url": "https://7cbc-2600-1700-5658-3c50-fdd0-8885-93fc-9d51.ngrok.io/extensions/00000000-0000-0000-0000-000000000000"
        }
      },
      "extensionPoints": ["Checkout::Feature::Render"],
      "localization": {
        "defaultLocale": "en",
        "lastUpdated": 1647632788,
        "translations": {
          "en": {
            "welcome": "Welcome to the {{extensionPoint}} extension!"
          },
          "fr": {
            "welcome": "Bienvenue dans l'extension {{extensionPoint}}!"
          }
        }
      },
      "metafields": [],
      "type": "checkout_ui_extension",
      "uuid": "00000000-0000-0000-0000-000000000000",
      "version": "",
      "surface": "checkout",
      "title": "Checkout UI Test Extension"
    }
  ]
}
```

</details>


### How are you solving it?
- Remove the getExtensionsWithLocalization() from happening at runtime on response to the /extensions/ endpoint
- Implement `fsnotify` in `build.WatchLocalization` to update an extension's Localization only when its locale files have changed.
https://github.com/Shopify/shopify-cli-extensions/blob/be7546b8d063f855eeec4bbb8e4eb7a7a08c8d73/build/build.go#L148
- To avoid interfering with assets' `LastUpdated` attribute, add a distinct `LastUpdated` timestamp attribute for Localization.
https://github.com/Shopify/shopify-cli-extensions/blob/be7546b8d063f855eeec4bbb8e4eb7a7a08c8d73/core/core.go#L86-L90

### Tophatting

<details>
<summary>Complete tophatting instructions</summary>

Create a Spin workspace:
```
spin up checkout-web,online-store-web --name cli-locales
```

### Local setup

While that's booting, set up your local machine.


In a _local_ shell, get the `shopify-cli-extensions` patch, and expose its package for linking:

```
dev clone shopify-cli-extensions
git checkout watch-locales
dev up
make bootstrap
cd packages/shopify-cli-extensions
yarn link
```

In a _local_ shell, setup [`shopify-cli`](https://github.com/Shopify/shopify-cli) and symlink `shopify-cli-extensions`:

```
dev clone shopify-cli
dev up
rake extensions:symlink
```

In a _local_ shell, get a reference extension from [`checkout-ui-extension-dev`](https://github.com/Shopify/checkout-ui-extension-dev), and link it to `shopify-cli-extensions`:
```
dev clone checkout-ui-extension-dev
git checkout new-cli
dev up
yarn link "@shopify/shopify-cli-extensions"
```

If you don't have `ngrok` configured, get a [token](https://dashboard.ngrok.com/get-started/your-authtoken) and add it to your local machine:

```
ngrok authtoken [the token string]
```

The `checkout-ui-extension-dev` repo provides `yarn shopify`, an alias to your local `shopify-cli` executable.

Make sure you are logged in to a development store (in _production_) that's [configured for extension development](https://checkout--add-extensions-spin-quick-star.docs.shopify.io/docs/referencedocs/web/extensions/development#standalone-extension) to work around [this bug](https://github.com/Shopify/shopify-cli/issues/1604). Example:

```
yarn shopify logout
yarn shopify login --store=https://your-dev-store.myshopify.com/
```

Select an [extension you use for development](https://checkout--add-extensions-spin-quick-star.docs.shopify.io/docs/referencedocs/web/extensions/development#standalone-extension).
```
yarn shopify extension connect
```

Run `shopify extension serve` using an alias:
```
yarn start
```

The output should end with something like:
```
┏━━ Serving extension… ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ DEBUG Sending configuration data to extension development server …
┃ DEBUG Starting message processing threads to relay output produced by the extension development server …
┃ Shopify CLI Extensions Server is now available at https://c52a-2600-1700-5658-3c50-11e0-9470-dd4c-d96e.ngrok.io
┃ <extension-name> (successfully built localization)
┃ 2022/04/04 09:59:14 Watcher added for: locales
┃ <extension-name> (Build succeeded)
```

### Viewing on checkout

Connect to the spin instance previously created and checkout the [mleandres/extensions-localization-hot-reload branch](https://github.com/Shopify/checkout-web/pull/9701) for `checkout-web`:
```
spin shell
> cd checkout-web
> git fetch origin mleandres/extensions-localization-hot-reload
> git checkout mleandres/extensions-localization-hot-reload
> update
```

Open your spin instance's shop website and create a checkout.
Copy the `ngrok` URL from the output of the previous `yarn start`
Append the following to the checkout URL in your browser, using your own `ngrok` URL:
- `?dev=https://76bc-96-20-124-218.ngrok.io/extensions/`

Example checkout URL:
- `https://shop1.shopify.cli-locales.martin-gilles-gingras.us.spin.dev/checkouts/c/a7a099f6700a0c343b3ac92c34935df5/information?dev=https://76bc-96-20-124-218.ngrok.io/extensions/`

In your browser, open the Network tab, use the `WS` filter and open the `extensions/` item:
<img width="600" alt="Screen Shot 2022-04-04 at 10 25 42 AM" src="https://user-images.githubusercontent.com/3000613/161565526-0ebd8fa3-88a9-414c-9c68-27f44c9dae1a.png">

This will show all incoming updates to either the code or the locale files of your running `checkout-ui-extension-dev` extension:
<img width="598" alt="Screen Shot 2022-04-04 at 10 28 40 AM" src="https://user-images.githubusercontent.com/3000613/161566000-96725dac-2e1f-48e3-9626-2f7d7f78b64e.png">

Inspect the contents of each update to validate the proper data is being sent.
Using the [mleandres/extensions-localization-hot-reload branch](https://github.com/Shopify/checkout-web/pull/9701) for `checkout-web`, you should see hot reloading of both extension code and localizations when receiving such updates.

</details>

### Result
<details>
<summary>Result video in Checkout</summary>

https://user-images.githubusercontent.com/3000613/161583386-9cdcff46-f1a8-4810-9643-d16a97a701db.mov

</details>

### Notes
This PR will set us up to implement proper hot module reloading in `checkout-ui-extensions` when locales change, via [this other pull request](https://github.com/Shopify/checkout-web/pull/9701). 

When a locale file changes, the `localization` property for that extension should be updated automatically both within the `HTTP GET /extensions/` endpoint and trigger an update in the websocket via `api.Notify([]core.Extension{extension})`. `api.Notify` takes care of merging the data and notifying all subscribers for you.