### PR TITLE
initial analytics extension setup

### DIFF
--- a/create/templates/projects/beacon_extension/extension.config.yml
+++ b/create/templates/projects/beacon_extension/extension.config.yml
@@ -1,0 +1,12 @@
+runtime_context: sandbox
+version: 1
+configuration:
+  type: object
+  fields:
+    trackingId:
+      name: Tracking Id
+      description: Tracking Id
+      type: single_line_text_field
+      validations:
+      - name: min
+        value: "1"

--- a/create/templates/projects/beacon_extension/src/index.js
+++ b/create/templates/projects/beacon_extension/src/index.js
@@ -1,0 +1,12 @@
+shopify.extend(
+  "Analytics",
+  (api) => {
+    const { config, subscribe, unsubscribe } = api;
+    // Bootstrap and insert pixel script tag here
+
+    // Sample subscribe to page view
+    subscribe('pageView', (event) => {
+
+    });
+  }
+);

--- a/testdata/extension.config.yml
+++ b/testdata/extension.config.yml
@@ -49,3 +49,15 @@ extensions:
         version: '^0.13.2'
       entries:
         main: 'src/index.tsx'
+  - uuid: 00000000-0000-0000-0000-000000000003
+    type: beacon_extension
+    title: Beacon Test Extension
+    development:
+      root_dir: 'tmp/beacon_extension'
+      build_dir: 'build'
+      template: 'javascript'
+      renderer:
+        name: '@shopify/checkout-ui-extensions'
+        version: '^0.14.0'
+      entries:
+        main: 'src/index.js'


### PR DESCRIPTION
ISSUE: https://github.com/Shopify/ce-customer-behaviour/issues/983
CLI:
https://github.com/Shopify/shopify-cli/pull/2075


Adds the beacon extension to the cli-extensions. This will be the only wait to create a new project. 