### PR TITLE
Rename `Checkout::Feature::Render` to `Checkout::Dynamic::Render`

### DIFF
--- a/create/templates/projects/checkout_ui_extension/extension.config.yml.tpl
+++ b/create/templates/projects/checkout_ui_extension/extension.config.yml.tpl
@@ -1,6 +1,6 @@
 ---
 extension_points:
-  - Checkout::Feature::Render
+  - Checkout::Dynamic::Render
 # metafields:
 #   - namespace: my-namespace
 #     key: my-key

--- a/create/templates/shared/checkout_ui_extension/javascript.js
+++ b/create/templates/shared/checkout_ui_extension/javascript.js
@@ -1,6 +1,6 @@
 import { extend, Text } from "@shopify/checkout-ui-extensions";
 
-extend("Checkout::Feature::Render", (root, { extensionPoint, i18n }) => {
+extend("Checkout::Dynamic::Render", (root, { extensionPoint, i18n }) => {
   root.appendChild(
     root.createComponent(
       Text,

--- a/create/templates/shared/checkout_ui_extension/react.js
+++ b/create/templates/shared/checkout_ui_extension/react.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import {render, Text} from '@shopify/checkout-ui-extensions-react';
+import {useExtensionApi, render, Text} from '@shopify/checkout-ui-extensions-react';
 
-render('Checkout::Feature::Render', App);
+render('Checkout::Dynamic::Render', () => <App />);
 
-function App({extensionPoint, i18n}) {
+function App() {
+  const {extensionPoint, i18n} = useExtensionApi();
   return <Text>{i18n.translate('welcome', {extensionPoint})}</Text>;
 }


### PR DESCRIPTION
This closes https://github.com/Shopify/checkout-web/issues/9871 which is a preview of some changes arriving soon to [@shopify/checkout-ui-extensions-react](https://www.npmjs.com/package/@shopify/checkout-ui-extensions-react)

In https://github.com/Shopify/checkout-web/pull/9705 we renamed the `Checkout::Feature::Render` extension point to `Checkout::Dynamic::Render`. They pretty much behave the same aside from placement references but those weren't supported yet in the development server.

* This fixes all extension points
* This tweaks the react extension to use `<App />` which will work better than the previous approach

## 🎩 

Here's how I tophatted:

```
make bootstrap
# Started my ngrok tunnel and added it to testdata/extension.config.yml
make run serve testdata/extension.config.yml
```

I then injected the extension to a `checkout-web` dev shop with this URL:

https://shop1.shopify.dynamic5.kumar-mcmillan.us.spin.dev/checkouts/c/50ea2d65f52c0d8a26d1f8ea7fef1103/information?dev=https%3A%2F%2Fb115-2600-1700-5658-3c50-a164-776e-e665-765c.ngrok.io%2Fextensions%2F

<details>
<summary>Extension result</summary>

<img width="1244" alt="Screen Shot 2022-04-07 at 2 53 31 PM" src="https://user-images.githubusercontent.com/55398/162286048-23d0674d-68c3-4cc6-be80-2d02dd849ea6.png">



</details>