### PR TITLE
Pass the node executable through the configuration object

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -746,6 +746,7 @@ func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
 			"extensionPoints": null,
 			"localization": null,
 			"surface": "checkout",
+			"node_executable": "",
 			"capabilities": {
 				"networkAccess": false
 			}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -746,7 +746,6 @@ func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
 			"extensionPoints": null,
 			"localization": null,
 			"surface": "checkout",
-			"node_executable": "",
 			"capabilities": {
 				"networkAccess": false
 			}

--- a/build/build.go
+++ b/build/build.go
@@ -19,7 +19,8 @@ import (
 const nextStepsTemplatePath = "templates/shared/%s/next-steps.txt"
 
 func Build(extension core.Extension, report ResultHandler) {
-	script, err := script(extension.BuildDir(), "build")
+	buildDir := extension.BuildDir()
+	script, err := script(buildDir, "shopify-cli-extensions", "build")
 	if err != nil {
 		report(Result{false, err.Error(), extension})
 		return

--- a/build/build.go
+++ b/build/build.go
@@ -21,10 +21,10 @@ const nextStepsTemplatePath = "templates/shared/%s/next-steps.txt"
 func Build(extension core.Extension, report ResultHandler) {
 	var err error
 	var command *exec.Cmd
-	if extension.NodeExecutable == "" {
+	if extension.NodeExecutable != "" {
 		command = nodeExecutableScript(extension.NodeExecutable, "build")
 	} else {
-		command, err = script(extension.BuildDir(), extension.NodeExecutable, "build")
+		command, err = script(extension.BuildDir(), "build")
 	}
 	if err != nil {
 		report(Result{false, err.Error(), extension})

--- a/build/build.go
+++ b/build/build.go
@@ -19,8 +19,14 @@ import (
 const nextStepsTemplatePath = "templates/shared/%s/next-steps.txt"
 
 func Build(extension core.Extension, report ResultHandler) {
-	buildDir := extension.BuildDir()
-	script, err := script(buildDir, "shopify-cli-extensions", "build")
+	buildCommand := extension.Commands["build"]
+	if len(buildCommand) == 0 {
+		buildCommand = "build"
+	}
+	splitCommand := strings.Split(buildCommand, " ")
+	buildCommand, args := splitCommand[0], splitCommand[1:]
+
+	script, err := script(extension.BuildDir(), buildCommand, args...)
 	if err != nil {
 		report(Result{false, err.Error(), extension})
 		return

--- a/build/build.go
+++ b/build/build.go
@@ -19,18 +19,24 @@ import (
 const nextStepsTemplatePath = "templates/shared/%s/next-steps.txt"
 
 func Build(extension core.Extension, report ResultHandler) {
-	script, err := script(extension.BuildDir(), extension.NodeExecutable, "build")
+	var err error
+	var command *exec.Cmd
+	if extension.NodeExecutable == "" {
+		command = nodeExecutableScript(extension.NodeExecutable, "build")
+	} else {
+		command, err = script(extension.BuildDir(), extension.NodeExecutable, "build")
+	}
 	if err != nil {
 		report(Result{false, err.Error(), extension})
 		return
 	}
 
-	if err := configureScript(script, extension); err != nil {
+	if err := configureScript(command, extension); err != nil {
 		report(Result{false, err.Error(), extension})
 	}
 	ensureBuildDirectoryExists(extension)
 
-	output, err := script.CombinedOutput()
+	output, err := command.CombinedOutput()
 	if err != nil {
 		report(Result{false, string(output), extension})
 		return
@@ -45,7 +51,7 @@ func Build(extension core.Extension, report ResultHandler) {
 }
 
 func Watch(extension core.Extension, integrationCtx core.IntegrationContext, report ResultHandler) {
-	script, err := script(extension.BuildDir(), extension.NodeExecutable, "develop")
+	script, err := script(extension.BuildDir(), "develop")
 	if err != nil {
 		report(Result{false, err.Error(), extension})
 		return

--- a/build/script.go
+++ b/build/script.go
@@ -10,11 +10,12 @@ var (
 	Command  = exec.Command
 )
 
-func script(dir, nodeExecutable string, script string, args ...string) (*exec.Cmd, error) {
-	if nodeExecutable != "" {
-		cmd := Command(nodeExecutable, append([]string{script}, args...)...)
-		return cmd, nil
-	} else if exe, err := LookPath("yarn"); err == nil {
+func nodeExecutableScript(nodeExecutable string, script string, args ...string) *exec.Cmd {
+	return Command(nodeExecutable, append([]string{script}, args...)...)
+}
+
+func script(dir, script string, args ...string) (*exec.Cmd, error) {
+	if exe, err := LookPath("yarn"); err == nil {
 		cmd := Command(exe, buildYarnArguments(script, args...)...)
 		cmd.Dir = dir
 		return cmd, nil

--- a/build/script.go
+++ b/build/script.go
@@ -10,8 +10,12 @@ var (
 	Command  = exec.Command
 )
 
-func script(dir, script string, args ...string) (*exec.Cmd, error) {
-	if exe, err := LookPath("yarn"); err == nil {
+func script(dir, nodeExecutable string, script string, args ...string) (*exec.Cmd, error) {
+	if nodeExecutable != "" {
+		cmd := Command(nodeExecutable, append([]string{script}, args...)...)
+		cmd.Dir = dir
+		return cmd, nil
+	} else if exe, err := LookPath("yarn"); err == nil {
 		cmd := Command(exe, buildYarnArguments(script, args...)...)
 		cmd.Dir = dir
 		return cmd, nil

--- a/build/script.go
+++ b/build/script.go
@@ -13,7 +13,6 @@ var (
 func script(dir, nodeExecutable string, script string, args ...string) (*exec.Cmd, error) {
 	if nodeExecutable != "" {
 		cmd := Command(nodeExecutable, append([]string{script}, args...)...)
-		cmd.Dir = dir
 		return cmd, nil
 	} else if exe, err := LookPath("yarn"); err == nil {
 		cmd := Command(exe, buildYarnArguments(script, args...)...)

--- a/build/script_test.go
+++ b/build/script_test.go
@@ -16,7 +16,7 @@ func TestYarnCommandStructure(t *testing.T) {
 		return "", errors.New("command not found")
 	}
 
-	cmd, err := script(".", "build", "some-arg")
+	cmd, err := script(".", "", "some-arg")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestNpmCommandStructure(t *testing.T) {
 		return "", errors.New("command not found")
 	}
 
-	cmd, err := script(".", "build", "some-arg")
+	cmd, err := script(".", "", "some-arg")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestPrefersYarn(t *testing.T) {
 		return "", errors.New("command not found")
 	}
 
-	script(".", "build")
+	script(".", "", "build")
 
 	if lookupOrder[0] != "yarn" {
 		t.Error("Expected yarn to be checked first")

--- a/build/script_test.go
+++ b/build/script_test.go
@@ -7,6 +7,17 @@ import (
 	"testing"
 )
 
+func TestNodeExecutableCommandStructure(t *testing.T) {
+	cmd, err := script(".", "/path/to/executable", "build", "some-arg")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(cmd.Args, []string{"/path/to/executable", "build", "some-arg"}) {
+		t.Errorf("Unexpected program arguments: %s", strings.Join(cmd.Args, " "))
+	}
+}
+
 func TestYarnCommandStructure(t *testing.T) {
 	LookPath = func(file string) (string, error) {
 		if file == "yarn" {
@@ -16,7 +27,7 @@ func TestYarnCommandStructure(t *testing.T) {
 		return "", errors.New("command not found")
 	}
 
-	cmd, err := script(".", "", "some-arg")
+	cmd, err := script(".", "", "build", "some-arg")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +45,7 @@ func TestNpmCommandStructure(t *testing.T) {
 		return "", errors.New("command not found")
 	}
 
-	cmd, err := script(".", "", "some-arg")
+	cmd, err := script(".", "", "build", "some-arg")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/build/script_test.go
+++ b/build/script_test.go
@@ -8,10 +8,7 @@ import (
 )
 
 func TestNodeExecutableCommandStructure(t *testing.T) {
-	cmd, err := script(".", "/path/to/executable", "build", "some-arg")
-	if err != nil {
-		t.Fatal(err)
-	}
+	cmd := nodeExecutableScript("/path/to/executable", "build", "some-arg")
 
 	if !reflect.DeepEqual(cmd.Args, []string{"/path/to/executable", "build", "some-arg"}) {
 		t.Errorf("Unexpected program arguments: %s", strings.Join(cmd.Args, " "))
@@ -27,7 +24,7 @@ func TestYarnCommandStructure(t *testing.T) {
 		return "", errors.New("command not found")
 	}
 
-	cmd, err := script(".", "", "build", "some-arg")
+	cmd, err := script(".", "build", "some-arg")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +42,7 @@ func TestNpmCommandStructure(t *testing.T) {
 		return "", errors.New("command not found")
 	}
 
-	cmd, err := script(".", "", "build", "some-arg")
+	cmd, err := script(".", "build", "some-arg")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +59,7 @@ func TestPrefersYarn(t *testing.T) {
 		return "", errors.New("command not found")
 	}
 
-	script(".", "", "build")
+	script(".", "build")
 
 	if lookupOrder[0] != "yarn" {
 		t.Error("Expected yarn to be checked first")

--- a/core/core.go
+++ b/core/core.go
@@ -105,6 +105,7 @@ type Extension struct {
 	Surface         string           `json:"surface" yaml:"-"`
 	Title           string           `json:"title,omitempty" yaml:"title,omitempty"`
 	Name            string           `json:"name,omitempty" yaml:"name,omitempty"`
+	NodeExecutable  string           `json:"node_executable" yaml:"node_executable,omitempty"`
 }
 
 func (e Extension) String() string {

--- a/core/core.go
+++ b/core/core.go
@@ -105,7 +105,7 @@ type Extension struct {
 	Surface         string           `json:"surface" yaml:"-"`
 	Title           string           `json:"title,omitempty" yaml:"title,omitempty"`
 	Name            string           `json:"name,omitempty" yaml:"name,omitempty"`
-	NodeExecutable  string           `json:"node_executable" yaml:"node_executable,omitempty"`
+	NodeExecutable  string           `json:"-" yaml:"node_executable,omitempty"`
 }
 
 func (e Extension) String() string {


### PR DESCRIPTION
I'm extending the configuration object that we pass through standard input to allow passing the path to the Node executable. When present, the logic defaults to it over running the executable through Yarn or NPM.