### PR TITLE
Adding POS UI Extensions into Shopify CLI Extensions

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -14,6 +14,7 @@ const (
 	Checkout     string = "checkout"
 	Admin        string = "admin"
 	PostPurchase string = "post-purchase"
+	POS          string = "pos"
 )
 
 func NewExtensionService(config *Config, apiRoot string) *ExtensionService {
@@ -199,6 +200,9 @@ func GetSurface(extension *Extension) string {
 	}
 	if strings.Contains(extension.Development.Renderer.Name, "post-purchase") {
 		return PostPurchase
+	}
+	if strings.Contains(extension.Development.Renderer.Name, "retail") {
+		return POS
 	}
 	return Admin
 }

--- a/create/templates/projects/pos_ui_extension/.shopify-cli.yml.tpl
+++ b/create/templates/projects/pos_ui_extension/.shopify-cli.yml.tpl
@@ -1,0 +1,1 @@
+{{- template "shared/shopify-cli.yml" . -}}

--- a/create/templates/projects/pos_ui_extension/package.json.tpl
+++ b/create/templates/projects/pos_ui_extension/package.json.tpl
@@ -1,0 +1,1 @@
+{{template "shared/package.json" .}}

--- a/create/templates/projects/pos_ui_extension/src/index.tpl
+++ b/create/templates/projects/pos_ui_extension/src/index.tpl
@@ -1,0 +1,5 @@
+{{- if .Development.UsesReact -}}
+{{ file "shared/pos_ui_extension/react.js" }}
+{{- else -}}
+{{ file "shared/pos_ui_extension/javascript.js" }}
+{{- end -}}

--- a/create/templates/shared/pos_ui_extension/javascript.js
+++ b/create/templates/shared/pos_ui_extension/javascript.js
@@ -1,0 +1,28 @@
+import { extend, Text } from "@shopify/retail-ui-extensions";
+
+extend('Retail::SmartGrid::Tile', (root, api) => {
+  const tileProps = {
+    title: 'My app',
+    subtitle: 'A test app',
+    enabled: true,
+    onPress: () => {
+      api.navigation.navigateToFullScreenModal();
+    }
+  }
+
+  const tile = root.createComponent('Tile', tileProps);
+
+  root.appendChild(tile);
+  root.mount();
+});
+
+extend('Retail::SmartGrid::Modal', (root, api) => {
+  root.appendChild(
+    root.createComponent(
+      Text,
+      {},
+      `Welcome to the ${api.extensionPoint} extension surface!`
+    )
+  );
+  root.mount();
+});

--- a/create/templates/shared/pos_ui_extension/next-steps.txt
+++ b/create/templates/shared/pos_ui_extension/next-steps.txt
@@ -1,0 +1,3 @@
+
+🔭 > To test your extension please visit the following URL:
+🔭 > {{.IntegrationContext.PublicUrl}} and click on the QR code and scan it with your phone

--- a/create/templates/shared/pos_ui_extension/react.js
+++ b/create/templates/shared/pos_ui_extension/react.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import {render, useExtensionApi, extend, Tile, Text} from '@shopify/retail-ui-extensions-react';
+
+const Tile = () => {
+  const api = useExtensionApi();
+
+  return(
+    <>
+      <Tile title="My app" subtitle="Welcome to my react app" enabled onPress={() => {api.navigation.navigateToFullScreenModal()}} />
+    </>
+  );
+}
+
+extend('Retail::SmartGrid::Tile', render(Tile));
+extend('Retail::SmartGrid::Modal', render(Modal));
+
+const Modal = () => {
+  return <Text>Welcome to the extension!</Text>;
+}

--- a/packages/dev-console-app/src/ActionSet/ActionSet.test.tsx
+++ b/packages/dev-console-app/src/ActionSet/ActionSet.test.tsx
@@ -83,4 +83,16 @@ describe('ActionSet', () => {
       }),
     );
   });
+
+  it('web url does not render if surface is pos', async () => {
+    const extension = mockExtension({surface: 'pos'});
+    const client = new ExtensionServerClient({connection: {url: 'ws://localhost'}});
+    const container = render(
+      <ActionSet extension={extension} />,
+      withProviders(DefaultProviders, TableWrapper),
+      {client},
+    );
+
+    expect(container.find(Action, {accessibilityLabel: i18n.translate('openRootUrl')})).toBeNull();
+  });
 });

--- a/packages/dev-console-app/src/ActionSet/ActionSet.tsx
+++ b/packages/dev-console-app/src/ActionSet/ActionSet.tsx
@@ -34,6 +34,7 @@ export function ActionSet(props: ActionSetProps) {
   const {extension, className, onShowMobileQRCode} = props;
   const {embedded, hide, navigate, refresh, show, state} = useDevConsoleInternal();
   const hidden = extension.development.hidden;
+  const hideWebUrl = extension.surface === 'pos';
 
   const handleShowHide = useCallback(() => {
     if (hidden) {
@@ -61,12 +62,14 @@ export function ActionSet(props: ActionSetProps) {
     <>
       <td>
         <div className={styles.ActionGroup}>
-          <Action
-            source={LinkIcon}
-            accessibilityLabel={i18n.translate('openRootUrl')}
-            onAction={handleOpenRoot}
-            className={className}
-          />
+          {!hideWebUrl && (
+            <Action
+              source={LinkIcon}
+              accessibilityLabel={i18n.translate('openRootUrl')}
+              onAction={handleOpenRoot}
+              className={className}
+            />
+          )}
           <div className={`${hidden ? rowStyles.ForceVisible : ''}`}>
             <Action
               source={hidden ? HideMinor : ViewMinor}

--- a/packages/dev-console-app/src/QRCodeModal/QRCodeModal.test.tsx
+++ b/packages/dev-console-app/src/QRCodeModal/QRCodeModal.test.tsx
@@ -60,4 +60,19 @@ describe('QRCodeModal', () => {
       children: i18n.translate('qrcode.useSecureURL'),
     });
   });
+
+  it('renders QRCode with pos deep-link url when surface is POS', async () => {
+    const app = mockApp();
+    const store = 'example.com';
+    const extension = mockExtension({surface: 'pos'});
+    const container = render(
+      <QRCodeModal extension={extension} onClose={jest.fn()} open />,
+      withProviders(DefaultProviders, ToastProvider),
+      {state: {app, store, extensions: [extension]}},
+    );
+
+    expect(container?.find(QRCode)?.prop('value')).toStrictEqual(
+      `com.shopify.pos://pos-ui-extensions?scriptUrl=${extension.development.root.url}`,
+    );
+  });
 });

--- a/packages/dev-console-app/src/QRCodeModal/QRCodeModal.tsx
+++ b/packages/dev-console-app/src/QRCodeModal/QRCodeModal.tsx
@@ -51,7 +51,11 @@ export function QRCodeContent(props: Pick<QRCodeModalProps, 'extension'>) {
       return undefined;
     }
 
-    return `https://${state.store}/admin/extensions-dev/mobile?url=${extension.development.root.url}`;
+    if (extension.surface === 'pos') {
+      return `com.shopify.pos://pos-ui-extensions?scriptUrl=${extension.development.root.url}`;
+    } else {
+      return `https://${state.store}/admin/extensions-dev/mobile?url=${extension.development.root.url}`;
+    }
   }, [extension, state.app, state.store]);
 
   const onButtonClick = useCallback(() => {

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
@@ -232,6 +232,9 @@ declare global {
     type EventUnsubscriber = () => void;
   }
 }
-export type Surface = 'checkout' | 'admin' | 'post-purchase';
+
+export const AVAILABLE_SURFACES = ['admin', 'checkout', 'post-checkout', 'pos'] as const;
+
+export type Surface = typeof AVAILABLE_SURFACES[number];
 
 export {};

--- a/packages/ui-extensions-server-kit/src/utilities/isValidSurface.ts
+++ b/packages/ui-extensions-server-kit/src/utilities/isValidSurface.ts
@@ -1,6 +1,6 @@
-import type {Surface} from '../ExtensionServerClient';
-
-const AVAILABLE_SURFACES = ['admin', 'checkout', 'post-checkout'];
+/* eslint-disable @shopify/strict-component-boundaries */
+import {AVAILABLE_SURFACES} from '../ExtensionServerClient/types';
+import type {Surface} from '../ExtensionServerClient/types';
 
 export function isValidSurface(surface: any): surface is Surface {
   return surface && AVAILABLE_SURFACES.includes(surface);

--- a/testdata/extension.config.yml
+++ b/testdata/extension.config.yml
@@ -117,3 +117,15 @@ extensions:
         main: 'src/index.js'
     capabilities:
       network_access: false
+  - uuid: 00000000-0000-0000-0000-000000000007
+    type: pos_ui_extension
+    title: POS UI Test Extension
+    development:
+      root_dir: 'tmp/pos_ui_extension'
+      build_dir: 'build'
+      template: 'typescript-react'
+      renderer:
+        name: '@shopify/retail-ui-extensions'
+        version: '^0.1.0'
+      entries:
+        main: 'src/index.tsx'


### PR DESCRIPTION
## Trying to achieve:
Adding POS UI Extension into Shopify CLI Extensions Template. Our goal is to `create`, `build`, and `serve` this new extension through Shopify CLI.

closes https://github.com/Shopify/shopify-cli-extensions/issues/272

## Things to look for: 
1. Am I missing any tests or other configurations?
2. Any suggestions for the `react` or `javascript` file?

## Things need to confirm:
Once the PR is approved, we only need to create tag and release it as described here: https://github.com/Shopify/shopify-cli-extensions#publishing-the-go-binary