### PR TITLE
adding capabilities list in lieu of canAccessNetwork flag

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -724,31 +724,33 @@ func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
 	}
 	expectedExtensions := fmt.Sprintf(`[
 		{
-		  "customData": "baz",
-		  "assets": {
+			"customData": "baz",
+			"assets": {
 			"main": {
-			  "name": "main",
-			  "url": "%v/extensions/00000000-0000-0000-0000-000000000000/assets/main.js",
-			  "lastUpdated": 0
+				"name": "main",
+				"url": "%v/extensions/00000000-0000-0000-0000-000000000000/assets/main.js",
+				"lastUpdated": 0
 			}
-		  },
-		  "development": {
+			},
+			"development": {
 			"hidden": false,
 			"resource": {"url": ""},
 			"root": {"url": "%v/extensions/00000000-0000-0000-0000-000000000000"},
 			"status": "success",
 			"resource": {"url": "cart/1234"}
-		  },
-		  "type": "checkout_ui_extension",
-		  "metafields": [{"namespace": "another-namespace", "key": "another-key"}],
-		  "uuid": "00000000-0000-0000-0000-000000000000",
-		  "version": "",
-		  "extensionPoints": null,
-		  "localization": null,
-		  "surface": "checkout",
-		  "canAccessNetwork": false
+			},
+			"type": "checkout_ui_extension",
+			"metafields": [{"namespace": "another-namespace", "key": "another-key"}],
+			"uuid": "00000000-0000-0000-0000-000000000000",
+			"version": "",
+			"extensionPoints": null,
+			"localization": null,
+			"surface": "checkout",
+			"capabilities": {
+				"networkAccess": false
+			}
 		}
-	  ]`, server.URL, server.URL)
+		]`, server.URL, server.URL)
 
 	match, err := isEqualJSON(expectedExtensions, string(extensions))
 	if err != nil {

--- a/core/core.go
+++ b/core/core.go
@@ -88,19 +88,23 @@ type Localization struct {
 	Translations  map[string]interface{} `json:"translations" yaml:"translations"`
 }
 
+type Capabilities struct {
+	NetworkAccess bool `json:"networkAccess" yaml:"network_access"`
+}
+
 type Extension struct {
-	Assets           map[string]Asset `json:"assets" yaml:"-"`
-	CanAccessNetwork bool             `json:"canAccessNetwork" yaml:"can_access_network,omitempty"`
-	Development      Development      `json:"development" yaml:"development,omitempty"`
-	ExtensionPoints  []string         `json:"extensionPoints" yaml:"extension_points,omitempty"`
-	Localization     *Localization    `json:"localization" yaml:"-"`
-	Metafields       []Metafield      `json:"metafields" yaml:"metafields,omitempty"`
-	Type             string           `json:"type" yaml:"type,omitempty"`
-	UUID             string           `json:"uuid" yaml:"uuid,omitempty"`
-	Version          string           `json:"version" yaml:"version,omitempty"`
-	Surface          string           `json:"surface" yaml:"-"`
-	Title            string           `json:"title,omitempty" yaml:"title,omitempty"`
-	Name             string           `json:"name,omitempty" yaml:"name,omitempty"`
+	Assets          map[string]Asset `json:"assets" yaml:"-"`
+	Capabilities    Capabilities     `json:"capabilities" yaml:"capabilities,omitempty"`
+	Development     Development      `json:"development" yaml:"development,omitempty"`
+	ExtensionPoints []string         `json:"extensionPoints" yaml:"extension_points,omitempty"`
+	Localization    *Localization    `json:"localization" yaml:"-"`
+	Metafields      []Metafield      `json:"metafields" yaml:"metafields,omitempty"`
+	Type            string           `json:"type" yaml:"type,omitempty"`
+	UUID            string           `json:"uuid" yaml:"uuid,omitempty"`
+	Version         string           `json:"version" yaml:"version,omitempty"`
+	Surface         string           `json:"surface" yaml:"-"`
+	Title           string           `json:"title,omitempty" yaml:"title,omitempty"`
+	Name            string           `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 func (e Extension) String() string {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -14,7 +14,8 @@ extensions:
 		type: checkout_ui_extension
 		title: Test Extension
 		name: Alternate Name
-		can_access_network: true
+		capabilities:
+			network_access: true
 `)
 
 	config, err := core.LoadConfig(strings.NewReader(serializedConfig))
@@ -38,15 +39,15 @@ extensions:
 	}
 
 	if extension.Title != "Test Extension" {
-		t.Errorf("invalid title - expected Test Extension go %s", extension.Title)
+		t.Errorf("invalid title - expected Test Extension got %s", extension.Title)
 	}
 
 	if extension.Name != "Alternate Name" {
-		t.Errorf("invalid name - expected Alternate Name go %s", extension.Name)
+		t.Errorf("invalid name - expected Alternate Name got %s", extension.Name)
 	}
 
-	if !extension.CanAccessNetwork {
-		t.Errorf("invalid value for CanAccessNetwork - expected true got %t", extension.CanAccessNetwork)
+	if extension.Capabilities.NetworkAccess != true {
+		t.Errorf("invalid value for Capabilities - expected network_access got %t", extension.Capabilities.NetworkAccess)
 	}
 }
 

--- a/testdata/extension.config.yml
+++ b/testdata/extension.config.yml
@@ -49,6 +49,8 @@ extensions:
         version: '^0.13.2'
       entries:
         main: 'src/index.tsx'
+    capabilities:
+      network_access: true
   - uuid: 00000000-0000-0000-0000-000000000003
     type: beacon_extension
     title: Beacon Test Extension
@@ -61,3 +63,5 @@ extensions:
         version: '^0.14.0'
       entries:
         main: 'src/index.js'
+    capabilities:
+      network_access: false


### PR DESCRIPTION
resolves internal Shopify issue.

Removes `CanAccessNetwork` bool in favor a `Capabilities` list. This change works with https://github.com/Shopify/shopify-cli/pull/2262

### Tophat

`make bootstrap`
`make run serve testdata/extension.config.yml`

| Command | Config yml | Expected json |
| - | - | - |
| `curl http://localhost:8000/extensions/00000000-0000-0000-0000-000000000001` | no capabilities added | `networkAccess: false` |
| `curl http://localhost:8000/extensions/00000000-0000-0000-0000-000000000003` | `network_access: false` | `networkAccess: false` |
| `curl http://localhost:8000/extensions/00000000-0000-0000-0000-000000000002` | `network_access: true` | `networkAccess: true` |