### PR TITLE
Add name to checkout_ui_extension config

### DIFF
--- a/create/templates/projects/checkout_ui_extension/extension.config.yml.tpl
+++ b/create/templates/projects/checkout_ui_extension/extension.config.yml.tpl
@@ -1,4 +1,5 @@
 ---
+name: App Feature
 extension_points:
   - Checkout::Dynamic::Render
 # metafields:


### PR DESCRIPTION
Ensure that extensions of type `checkout_ui_extension` have a name.