### PR TITLE
Rename from shopify.extension.toml to shopify.ui.extension.toml

### DIFF
--- a/create/templates/projects/checkout_post_purchase_next/shopify.ui.extension.toml.tpl
+++ b/create/templates/projects/checkout_post_purchase_next/shopify.ui.extension.toml.tpl
@@ -1,4 +1,4 @@
-{{ template "shared/shopify.extension.toml" . }}
+{{ template "shared/shopify.ui.extension.toml" . }}
 
 # [[metafields]]
 # namespace: my-namespace

--- a/create/templates/projects/checkout_ui_extension_next/shopify.ui.extension.toml.tpl
+++ b/create/templates/projects/checkout_ui_extension_next/shopify.ui.extension.toml.tpl
@@ -1,4 +1,4 @@
-{{- template "shared/shopify.extension.toml" . }}
+{{- template "shared/shopify.ui.extension.toml" . }}
 
 extension_points = [
   'Checkout::Dynamic::Render'

--- a/create/templates/projects/product_subscription_next/shopify.extension.toml.tpl
+++ b/create/templates/projects/product_subscription_next/shopify.extension.toml.tpl
@@ -1,1 +1,0 @@
-{{- template "shared/shopify.extension.toml" . -}}

--- a/create/templates/projects/product_subscription_next/shopify.ui.extension.toml.tpl
+++ b/create/templates/projects/product_subscription_next/shopify.ui.extension.toml.tpl
@@ -1,0 +1,1 @@
+{{- template "shared/shopify.ui.extension.toml" . -}}


### PR DESCRIPTION
Because all extensions are placed under `/extensions` (theme, argo, and function extensions) in the new unified app model, the CLI needs a way to disambiguate the type of extension. We'll be doing that through the name of the configuration file.
Because of that, I'm renaming the `_next` templates to reflect this. 