### PR TITLE
Fix issues with websocket messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,16 +37,21 @@ endif
 	md5sum ${executable} > ${canonical_name}.md5
 	gzip ${executable} && mv ${executable}.gz ${canonical_name}.gz
 
-.PHONY: test
-test:
+.PHONY: js-test
+js-test:
 	yarn install
 	yarn test
 
+.PHONY: go-test
+go-test:
 	# Create mock app folder to get go test running
 	rm -rf api/dev-console
 	mkdir api/dev-console
 	touch api/dev-console/index.html
 	go test ./...
+
+.PHONY: test
+test: js-test go-test
 
 ifeq (serve-dev,$(firstword $(MAKECMDGOALS)))
   SHOPIFILE := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))


### PR DESCRIPTION
This PR fixes 3 issues with the websockets:
- Fix issue where websocket messages were being sent to a closed channel
   
   ![image](https://user-images.githubusercontent.com/29458473/167918623-0e1134f3-ae92-44b0-8513-8af8333fe727.png)
- Fix error where websocket messages were sent concurrently 
- Suppress writing to a broken pipe error. Once we encounter this error we can safely stop attempting to send notifications as the client has already closed the connection.

Fixes https://github.com/Shopify/shopify-cli-extensions/issues/295 as a result of resolve the above issues.

### Tophat

#### Setup
1. Follow the instructions here to test with a local version of the CLI + the Go binary: https://github.com/Shopify/shopify-cli-extensions#testing-the-integration-with-the-shopify-cli. Ensure you follow the step to set up the `symlink` to the Go binary.

#### Test live reload after a failed build 
1. Create a Checkout UI Extension
2. Run `shopify extension serve`
3. Click on the link to load the extension in Checkout
4. Make valid changes to the extension and verify that the live reload works
5. Make some syntax errors in your extension verify that the extension does not reload in Checkout
6. Fix the syntax errors and make some new changes in your extension
7. Verify that the extension is reloaded with the new changes

https://user-images.githubusercontent.com/29458473/167738753-e327eb5a-f1cf-4c00-aa72-582b6127c66f.mov


#### Test multiple connections
NOTE: Currently the issues with concurrent messages can be seen more easily with the Product Subscription extension as it attempts to connect the web socket twice. Don't worry if you see the "Resource url missing" error message - this is unrelated to web sockets and  will be fixed in a follow up PR.

1. Create a new Product Subscription extension.
2. Run `shopify extension serve`
3. Click on the link to load in Admin
4. Open Chrome dev tools and reload the page
5. Click on the Network tab and filter for WS connections
6. Verify that the first connection to the web socket is closed and no errors is thrown by the Dev Server
7. Verify that the second connection to the web socket can receive updates by opening the Dev Console and toggling show/hide or by making edits to your extension
8. Close Admin and verify that no errors is thrown by the Dev Server

https://user-images.githubusercontent.com/29458473/167738766-6d597e0f-88e4-4bb4-a095-c8e4e56ed7f7.mov

