### PR TITLE
Resolution for @types/react for checkout ui ext

### DIFF
--- a/create/templates/shared/package.json
+++ b/create/templates/shared/package.json
@@ -14,5 +14,8 @@
   "scripts": {
     "build": "shopify-cli-extensions build",
     "develop": "shopify-cli-extensions develop"
-  }
+  }{{ if and .Development.UsesTypeScript .Development.UsesReact }},
+  "resolutions": {
+    "@types/react": "17.0.2"
+  }{{ end }}
 }


### PR DESCRIPTION
Fixes #290.

**Problem**
When creating a new typescript react checkout extension, all react components show typescript errors.

**Solution**
Added a specific resolution to the `package.json` template for `"@types/react": "17.0.2"`. This will only be added if the extension being created is Typescript + React.

> Bonus: added a test for this as well. 

🎩**Tophatting**
1. Clone both this repo and `shopify-cli`.
2. In `shopify-cli-extensions` checkout this patch.
3. In `shopify-cli-extensions` run `make boostrap`.
4. In `shopify-cli` run `bundle install` followed by `rake extensions:symlink` (this will link your local `shopify-cli-extensions` build.
5. Run `alias shopifyls="SHOPIFY_CLI_DEVELOPMENT=1 SSL_VERIFY_NONE=1 $HOME/src/github.com/Shopify/shopify-cli/bin/shopify"` 
6. Run `shopifyls extension create` and select `typescript-react` as the option for a checkout extension.
7. Open the code and verify you have no typescript errors.
 