### PR TITLE
Allow passing the selected surface to the Dev Console as a search param

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -32,7 +32,10 @@ func NewExtensionService(config *Config, apiRoot string) *ExtensionService {
 			extension.Assets[name] = Asset{Name: name}
 		}
 
-		extension.Surface = GetSurface(&extension)
+		if extension.Surface == "" {
+			extension.Surface = GetSurface(&extension)
+		}
+
 		extensions = append(extensions, extension)
 	}
 	// TODO: Improve this when we need to read more app configs,
@@ -103,7 +106,7 @@ type Extension struct {
 	Type            string           `json:"type" yaml:"type,omitempty"`
 	UUID            string           `json:"uuid" yaml:"uuid,omitempty"`
 	Version         string           `json:"version" yaml:"version,omitempty"`
-	Surface         string           `json:"surface" yaml:"-"`
+	Surface         string           `json:"surface" yaml:"surface"`
 	Title           string           `json:"title,omitempty" yaml:"title,omitempty"`
 	Name            string           `json:"name,omitempty" yaml:"name,omitempty"`
 	NodeExecutable  string           `json:"-" yaml:"node_executable,omitempty"`

--- a/packages/dev-console-app/package.json
+++ b/packages/dev-console-app/package.json
@@ -33,7 +33,7 @@
     "sass": "^1.42.1",
     "ts-jest": "^27.0.5",
     "ts-node": "^10.2.1",
-    "typescript": "^4.3.2",
+    "typescript": "^4.6.4",
     "vite": "^2.4.4",
     "vite-jest": "^0.0.3",
     "vite-tsconfig-paths": "^3.3.14"

--- a/packages/dev-console-app/src/App.tsx
+++ b/packages/dev-console-app/src/App.tsx
@@ -3,17 +3,19 @@ import '@shopify/polaris/dist/styles.css';
 import enTranslations from '@shopify/polaris/locales/en.json';
 import {AppProvider} from '@shopify/polaris';
 import {I18nContext, I18nManager} from '@shopify/react-i18n';
-import {ExtensionServerProvider} from '@shopify/ui-extensions-server-kit';
+import {ExtensionServerProvider, isValidSurface} from '@shopify/ui-extensions-server-kit';
 
 import * as styles from './theme.module.css';
 import {DevConsole} from './DevConsole';
 
 const protocol = location.protocol === 'http:' ? 'ws:' : 'wss:';
 const host = (import.meta.env.VITE_WEBSOCKET_HOST as string) || location.host;
+const surface = new URLSearchParams(location.search).get('surface');
 const extensionServerOptions = {
   connection: {
     url: `${protocol}//${host}/extensions/`,
   },
+  surface: isValidSurface(surface) ? surface : undefined,
 };
 
 const locale = 'en';

--- a/packages/dev-console-app/src/DevConsole.module.scss
+++ b/packages/dev-console-app/src/DevConsole.module.scss
@@ -137,3 +137,9 @@
 .UIExtensionsDevToolOverrides {
   overflow: hidden;
 }
+
+.Empty {
+  width: 100%;
+  text-align: center;
+  padding: 1.5rem;
+}

--- a/packages/dev-console-app/src/DevConsole.tsx
+++ b/packages/dev-console-app/src/DevConsole.tsx
@@ -42,6 +42,9 @@ export function DevConsole() {
     hide,
     focus,
     unfocus,
+    client: {
+      options: {surface},
+    },
   } = useDevConsoleInternal();
 
   const allSelected = selectedExtensionsSet.size === extensions.length;
@@ -121,6 +124,70 @@ export function DevConsole() {
       </aside>
     ) : null;
 
+  const ConsoleContent = () => (
+    <section className={styles.ExtensionList}>
+      <table>
+        <thead>
+          <tr>
+            <th>
+              <Checkbox
+                label={
+                  allSelected
+                    ? i18n.translate('bulkActions.deselectAll')
+                    : i18n.translate('bulkActions.selectAll')
+                }
+                checked={allSelected}
+                onChange={toggleSelectAll}
+                labelHidden
+              />
+            </th>
+            <th>{i18n.translate('extensionList.name')}</th>
+            <th>{i18n.translate('extensionList.type')}</th>
+            <th>{i18n.translate('extensionList.status')}</th>
+            <th>
+              <div className={actionSetStyles.ActionGroup}>
+                {actionHeaderMarkup}
+                <Action
+                  source={RefreshMinor}
+                  accessibilityLabel={i18n.translate('extensionList.refresh')}
+                  onAction={refreshSelectedExtensions}
+                />
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {extensions.map((extension) => {
+            const uuid = extension.uuid;
+            return (
+              <ExtensionRow
+                key={uuid}
+                extension={extension}
+                onSelect={toggleSelect}
+                selected={selectedExtensionsSet.has(uuid)}
+                onHighlight={focus}
+                onClearHighlight={unfocus}
+                onCloseMobileQRCode={() => setActiveMobileQRCodeExtension(undefined)}
+                onShowMobileQRCode={setActiveMobileQRCodeExtension}
+              />
+            );
+          })}
+        </tbody>
+      </table>
+    </section>
+  );
+
+  const ConsoleEmpty = () => {
+    return (
+      // eslint-disable-next-line @shopify/jsx-prefer-fragment-wrappers
+      <div>
+        {surface
+          ? i18n.translate('errors.noExtensionsForSurface', {surface})
+          : i18n.translate('errors.noExtensions')}
+      </div>
+    );
+  };
+
   return (
     <ToastProvider>
       <div className={styles.OuterContainer}>
@@ -133,58 +200,7 @@ export function DevConsole() {
           </header>
           <main>
             <ConsoleSidenav />
-            {extensions.length > 0 && (
-              <section className={styles.ExtensionList}>
-                <table>
-                  <thead>
-                    <tr>
-                      <th>
-                        <Checkbox
-                          label={
-                            allSelected
-                              ? i18n.translate('bulkActions.deselectAll')
-                              : i18n.translate('bulkActions.selectAll')
-                          }
-                          checked={allSelected}
-                          onChange={toggleSelectAll}
-                          labelHidden
-                        />
-                      </th>
-                      <th>{i18n.translate('extensionList.name')}</th>
-                      <th>{i18n.translate('extensionList.type')}</th>
-                      <th>{i18n.translate('extensionList.status')}</th>
-                      <th>
-                        <div className={actionSetStyles.ActionGroup}>
-                          {actionHeaderMarkup}
-                          <Action
-                            source={RefreshMinor}
-                            accessibilityLabel={i18n.translate('extensionList.refresh')}
-                            onAction={refreshSelectedExtensions}
-                          />
-                        </div>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {extensions.map((extension) => {
-                      const uuid = extension.uuid;
-                      return (
-                        <ExtensionRow
-                          key={uuid}
-                          extension={extension}
-                          onSelect={toggleSelect}
-                          selected={selectedExtensionsSet.has(uuid)}
-                          onHighlight={focus}
-                          onClearHighlight={unfocus}
-                          onCloseMobileQRCode={() => setActiveMobileQRCodeExtension(undefined)}
-                          onShowMobileQRCode={setActiveMobileQRCodeExtension}
-                        />
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </section>
-            )}
+            {extensions.length > 0 ? <ConsoleContent /> : <ConsoleEmpty />}
             <QRCodeModal
               extension={activeMobileQRCodeExtension}
               open={activeMobileQRCodeExtension !== undefined}

--- a/packages/dev-console-app/src/DevConsole.tsx
+++ b/packages/dev-console-app/src/DevConsole.tsx
@@ -179,8 +179,7 @@ export function DevConsole() {
 
   const ConsoleEmpty = () => {
     return (
-      // eslint-disable-next-line @shopify/jsx-prefer-fragment-wrappers
-      <div>
+      <div className={styles.Empty}>
         {surface
           ? i18n.translate('errors.noExtensionsForSurface', {surface})
           : i18n.translate('errors.noExtensions')}

--- a/packages/dev-console-app/src/translations/en.json
+++ b/packages/dev-console-app/src/translations/en.json
@@ -14,5 +14,9 @@
     "hide": "Hide",
     "selectAll": "Select all",
     "deselectAll": "Deselect all"
+  },
+  "errors": {
+    "noExtensions": "No extensions found",
+    "noExtensionsForSurface": "No extensions found for the surface: {surface}"
   }
 }

--- a/packages/shopify-cli-extensions-test-utils/package.json
+++ b/packages/shopify-cli-extensions-test-utils/package.json
@@ -23,7 +23,7 @@
     "ts-jest": "^27.0.5",
     "ts-node": "^10.2.1",
     "tsc": "^2.0.3",
-    "typescript": "^4.3.2"
+    "typescript": "^4.6.4"
   },
   "resolutions": {
     "@types/react": "16.14.0"

--- a/packages/shopify-cli-extensions/package.json
+++ b/packages/shopify-cli-extensions/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^16.7.1",
     "prettier": "^2.3.2",
     "ts-node": "^10.2.1",
-    "typescript": "^4.3.5"
+    "typescript": "^4.6.4"
   },
   "dependencies": {
     "@luckycatfactory/esbuild-graphql-loader": "^3.6.0",

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -44,7 +44,7 @@
     "ts-jest": "^27.0.5",
     "ts-node": "^10.2.1",
     "tsc": "^2.0.3",
-    "typescript": "^4.3.2",
+    "typescript": "^4.6.4",
     "vite": "^2.4.4",
     "vite-tsconfig-paths": "^3.3.14"
   },

--- a/packages/ui-extensions-server-kit/package.json
+++ b/packages/ui-extensions-server-kit/package.json
@@ -39,6 +39,7 @@
     "@types/react-dom": "^16.9.11",
     "@vitejs/plugin-react-refresh": "^1.3.1",
     "jest": "^27.1.0",
+    "jest-fetch-mock": "^3.0.3",
     "jest-websocket-mock": "^2.2.1",
     "mock-socket": "^9.0.5",
     "ts-jest": "^27.0.5",

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/APIClient.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/APIClient.ts
@@ -1,10 +1,15 @@
+import type {Surface} from './types';
+
 export class APIClient implements ExtensionServer.API.Client {
-  constructor(public url: string) {}
+  constructor(public url: string, public surface?: Surface) {}
 
   async extensions(): Promise<ExtensionServer.API.ExtensionsResponse> {
     const response = await fetch(`${this.url}/extensions`);
     const dto: ExtensionServer.API.ExtensionsResponse = await response.json();
-    return dto;
+    const filteredExtensions = dto.extensions.filter(
+      (extension) => !this.surface || extension.surface === this.surface,
+    );
+    return {...dto, extensions: filteredExtensions};
   }
 
   async extensionById(id: string): Promise<ExtensionServer.API.ExtensionResponse> {

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
@@ -24,16 +24,6 @@ describe('ExtensionServerClient', () => {
     return {socket, client, options};
   }
 
-  // beforeEach(() => {
-  //   // eslint-disable-next-line jest/prefer-spy-on
-  //   global.fetch = jest.fn().mockImplementationOnce(() =>
-  //     Promise.resolve({
-  //       status: 400,
-  //       json: () => Promise.resolve({success: false, error: 'Something bad happened'}),
-  //     }),
-  //   );
-  // });
-
   describe('initialization', () => {
     it('connects to the target websocket', async () => {
       const {socket, client} = setup();

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/index.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/index.ts
@@ -1,1 +1,2 @@
 export * from './ExtensionServerClient';
+export * from './types';

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
@@ -53,6 +53,10 @@ declare global {
          */
         protocols?: string | string[];
       };
+      /**
+       * If provided the extension server will only return extensions that matches the specified surface
+       */
+      surface?: Surface;
     }
 
     /**
@@ -60,6 +64,11 @@ declare global {
      * communicate with the extension server.
      */
     interface Client {
+      /**
+       * Connection options
+       */
+      options: Options;
+
       /**
        * Reconnecting WebSocket Client
        */
@@ -141,7 +150,7 @@ declare global {
         assets: Assets;
         development: Development;
         extensionPoints: string[] | null;
-        surface: string;
+        surface: Surface;
         name?: string;
         title?: string;
         type: string;
@@ -223,5 +232,6 @@ declare global {
     type EventUnsubscriber = () => void;
   }
 }
+export type Surface = 'checkout' | 'admin' | 'post-purchase';
 
 export {};

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
@@ -23,7 +23,7 @@ declare global {
       //
     }
 
-    interface OutboundDispatchEvents {
+    interface DispatchEvents {
       //
     }
 
@@ -99,7 +99,7 @@ declare global {
       /**
        * Function to emit an event to the extension server.
        */
-      emit<TEvent extends keyof OutboundDispatchEvents>(...args: EmitArgs<TEvent>): void;
+      emit<TEvent extends keyof DispatchEvents>(...args: EmitArgs<TEvent>): void;
 
       /**
        * Function that opens a connection with the extensions server.
@@ -204,10 +204,10 @@ declare global {
      * In practice, this will allow TypeScript to type-check the event being emitted
      * and, if the payload isn't required, the second argument won't be necessary.
      */
-    type EmitArgs<TEvent extends keyof ExtensionServer.OutboundDispatchEvents> =
-      ExtensionServer.OutboundDispatchEvents[TEvent] extends void
+    type EmitArgs<TEvent extends keyof ExtensionServer.DispatchEvents> =
+      ExtensionServer.DispatchEvents[TEvent] extends void
         ? [event: TEvent]
-        : [event: TEvent, payload: ExtensionServer.OutboundDispatchEvents[TEvent]];
+        : [event: TEvent, payload: ExtensionServer.DispatchEvents[TEvent]];
 
     /**
      * This is a helper interface that allows us to define the static methods of a given

--- a/packages/ui-extensions-server-kit/src/context/ExtensionServerProvider.tsx
+++ b/packages/ui-extensions-server-kit/src/context/ExtensionServerProvider.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useMemo, useState} from 'react';
 
+import {isValidSurface} from '../utilities/isValidSurface';
 import {
   createConnectedAction,
   createUpdateAction,
@@ -14,17 +15,24 @@ import {useExtensionServerState} from '../hooks/useExtensionServerState';
 import {extensionServerContext} from './constants';
 import type {ExtensionServerProviderProps} from './types';
 
+function getValidatedOptions(options: ExtensionServer.Options): ExtensionServer.Options {
+  if (!isValidSurface(options.surface)) {
+    delete options.surface;
+  }
+  return options;
+}
+
 export function ExtensionServerProvider({
   children,
   options: defaultOptions,
 }: ExtensionServerProviderProps) {
   const [state, dispatch] = useExtensionServerState();
-  const [options, setOptions] = useState(defaultOptions);
+  const [options, setOptions] = useState(getValidatedOptions(defaultOptions));
   const [client] = useState<ExtensionServer.Client>(() => new ExtensionServerClient());
 
   const connect = useCallback(
     (newOptions: ExtensionServer.Options = options) => {
-      setOptions({...newOptions});
+      setOptions(getValidatedOptions(newOptions));
     },
     [options],
   );

--- a/packages/ui-extensions-server-kit/src/context/ExtensionServerProvider.tsx
+++ b/packages/ui-extensions-server-kit/src/context/ExtensionServerProvider.tsx
@@ -1,6 +1,5 @@
 import React, {useCallback, useMemo, useState} from 'react';
 
-import {isValidSurface} from '../utilities/isValidSurface';
 import {
   createConnectedAction,
   createUpdateAction,
@@ -15,24 +14,17 @@ import {useExtensionServerState} from '../hooks/useExtensionServerState';
 import {extensionServerContext} from './constants';
 import type {ExtensionServerProviderProps} from './types';
 
-function getValidatedOptions(options: ExtensionServer.Options): ExtensionServer.Options {
-  if (!isValidSurface(options.surface)) {
-    delete options.surface;
-  }
-  return options;
-}
-
 export function ExtensionServerProvider({
   children,
   options: defaultOptions,
 }: ExtensionServerProviderProps) {
   const [state, dispatch] = useExtensionServerState();
-  const [options, setOptions] = useState(getValidatedOptions(defaultOptions));
+  const [options, setOptions] = useState(defaultOptions);
   const [client] = useState<ExtensionServer.Client>(() => new ExtensionServerClient());
 
   const connect = useCallback(
     (newOptions: ExtensionServer.Options = options) => {
-      setOptions(getValidatedOptions(newOptions));
+      setOptions(newOptions);
     },
     [options],
   );

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -4,13 +4,24 @@ import type {Surface} from './ExtensionServerClient/types';
 
 declare global {
   namespace ExtensionServer {
-    interface InboundEvents {
+    type ServerEvents =
+      | {
+          event: 'dispatch';
+          data: InboundEvents['dispatch'];
+        }
+      | {
+          event: 'connected';
+          data: InboundEvents['connected'];
+        }
+      | {
+          event: 'update';
+          data: InboundEvents['update'];
+        };
+
+    interface InboundEvents extends DispatchEvents {
+      dispatch: {type: keyof DispatchEvents; payload: DispatchEvents[keyof DispatchEvents]};
       connected: {extensions: ExtensionPayload[]; app?: App; store: string};
       update: {extensions?: ExtensionPayload[]; app?: App};
-      refresh: {uuid: string}[];
-      focus: {uuid: string}[];
-      unfocus: void;
-      navigate: {url: string};
     }
 
     interface OutboundPersistEvents {
@@ -20,7 +31,7 @@ declare global {
       };
     }
 
-    interface OutboundDispatchEvents {
+    interface DispatchEvents {
       refresh: {uuid: string}[];
       focus: {uuid: string}[];
       unfocus: void;

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-namespace, @shopify/strict-component-boundaries */
 import './ExtensionServerClient/types';
+import type {Surface} from './ExtensionServerClient/types';
 
 declare global {
   namespace ExtensionServer {
@@ -58,7 +59,7 @@ export interface ExtensionPayload {
   };
   uuid: string;
   version: string;
-  surface: string;
+  surface: Surface;
   title: string;
 }
 

--- a/packages/ui-extensions-server-kit/src/utilities/index.ts
+++ b/packages/ui-extensions-server-kit/src/utilities/index.ts
@@ -3,3 +3,4 @@ export * from './noop';
 export * from './replaceUpdated';
 export * from './set';
 export * from './resourceURLtoString';
+export * from './isValidSurface';

--- a/packages/ui-extensions-server-kit/src/utilities/isValidSurface.ts
+++ b/packages/ui-extensions-server-kit/src/utilities/isValidSurface.ts
@@ -1,5 +1,7 @@
 import type {Surface} from '../ExtensionServerClient';
 
+const AVAILABLE_SURFACES = ['admin', 'checkout', 'post-checkout'];
+
 export function isValidSurface(surface: any): surface is Surface {
-  return (surface && surface === 'admin') || surface === 'checkout' || surface === 'post-purchase';
+  return surface && AVAILABLE_SURFACES.includes(surface);
 }

--- a/packages/ui-extensions-server-kit/src/utilities/isValidSurface.ts
+++ b/packages/ui-extensions-server-kit/src/utilities/isValidSurface.ts
@@ -1,0 +1,5 @@
+import type {Surface} from '../ExtensionServerClient';
+
+export function isValidSurface(surface: any): surface is Surface {
+  return (surface && surface === 'admin') || surface === 'checkout' || surface === 'post-purchase';
+}

--- a/testdata/extension.config.yml
+++ b/testdata/extension.config.yml
@@ -26,6 +26,7 @@ extensions:
     type: checkout_ui_extension_next
     title: Checkout UI Test Extension Next
     node_executable: packages/shopify-cli-extensions/cli.js
+    surface: checkout
     metafields:
       - namespace: my-namespace
         key: my-key
@@ -56,6 +57,7 @@ extensions:
     type: product_subscription_next
     title: Product Subscription Test Extension Next
     node_executable: packages/shopify-cli-extensions/cli.js
+    surface: admin
     development:
       root_dir: 'tmp/product_subscription_next'
       build_dir: 'build'
@@ -86,6 +88,7 @@ extensions:
     type: checkout_post_purchase_next
     title: Post Purchase Test Extension Next
     node_executable: packages/shopify-cli-extensions/cli.js
+    surface: post-purchase
     metafields:
       - namespace: my-namespace
         key: my-key

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,27 +2150,13 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.14.0", "@types/react@^16", "@types/react@^16.9.12":
+"@types/react@*", "@types/react@16.14.0", "@types/react@>=17.0.0 <18.0.0", "@types/react@^16", "@types/react@^16.9.12":
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.0.tgz#bc022cfe1609899b0f2196376b267724e7300f0e"
   integrity sha512-jJjHo1uOe+NENRIBvF46tJimUvPnmbQ41Ax0pEm7pRvhPg+wuj8VMOHHiMvaGmZRzRrCtm7KnL5OOE/6kHPK8w==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
-
-"@types/react@>=17.0.0 <18.0.0":
-  version "17.0.44"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
-  integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/scheduler@*":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
-  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
@@ -3435,6 +3421,13 @@ cross-fetch@3.1.4:
   integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
   dependencies:
     node-fetch "2.6.1"
+
+cross-fetch@^3.0.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -5592,6 +5585,14 @@ jest-environment-node@^27.2.0:
     jest-mock "^27.1.1"
     jest-util "^27.2.0"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
@@ -6690,6 +6691,13 @@ node-fetch@2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@^2.6.1:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
@@ -7490,6 +7498,11 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-polyfill@^8.1.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.3.tgz#2edc7e4b81aff781c88a0d577e5fe9da822107c6"
+  integrity sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==
 
 promise-retry@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,13 +2150,27 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.14.0", "@types/react@>=17.0.0 <18.0.0", "@types/react@^16", "@types/react@^16.9.12":
+"@types/react@*", "@types/react@16.14.0", "@types/react@^16", "@types/react@^16.9.12":
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.0.tgz#bc022cfe1609899b0f2196376b267724e7300f0e"
   integrity sha512-jJjHo1uOe+NENRIBvF46tJimUvPnmbQ41Ax0pEm7pRvhPg+wuj8VMOHHiMvaGmZRzRrCtm7KnL5OOE/6kHPK8w==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
+
+"@types/react@>=17.0.0 <18.0.0":
+  version "17.0.45"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.45.tgz#9b3d5b661fd26365fefef0e766a1c6c30ccf7b3f"
+  integrity sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8980,10 +8980,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.2, typescript@^4.3.5:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+typescript@^4.6.4:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 uglify-js@^3.1.4:
   version "3.14.2"


### PR DESCRIPTION
Related to https://github.com/Shopify/shopify-cli-extensions/issues/306

### Changes

Allow passing the selected surface to the Dev Console as a search param
- Filter extension selected surface for all events coming from the Dev Server

Manually set the surface for CLI 3.0 extensions to prevent them from being set to "admin" by default

### Tophat

1. Pull this branch and run `make clobber; make bootstrap`
2. Run `make run serve testdata/extension.config.yml`
3. Open http://localhost:8000?surface=admin
4. Verify that you only see Product Subscription extensions

![image](https://user-images.githubusercontent.com/29458473/169355154-fcec03f4-49d9-4643-a36e-7ca1b09110e0.png)


