### PR TITLE
Fix Serve path & build bugs

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -27,7 +27,7 @@ func Build(extension core.Extension, report ResultHandler) {
 	var err error
 	var command *exec.Cmd
 	if extension.NodeExecutable != "" {
-		command = nodeExecutableScript(extension.NodeExecutable, "build")
+		command = nodeExecutableScript(extension.Development.RootDir, extension.NodeExecutable, "build")
 	} else {
 		command, err = script(extension.BuildDir(), "build")
 	}
@@ -59,7 +59,7 @@ func Watch(extension core.Extension, integrationCtx core.IntegrationContext, rep
 	var err error
 	var command *exec.Cmd
 	if extension.NodeExecutable != "" {
-		command = nodeExecutableScript(extension.NodeExecutable, "develop")
+		command = nodeExecutableScript(extension.Development.RootDir, extension.NodeExecutable, "develop")
 	} else {
 		command, err = script(extension.BuildDir(), "develop")
 	}

--- a/build/script.go
+++ b/build/script.go
@@ -10,8 +10,10 @@ var (
 	Command  = exec.Command
 )
 
-func nodeExecutableScript(nodeExecutable string, script string, args ...string) *exec.Cmd {
-	return Command(nodeExecutable, append([]string{script}, args...)...)
+func nodeExecutableScript(dir, nodeExecutable string, script string, args ...string) *exec.Cmd {
+	cmd := Command(nodeExecutable, append([]string{script}, args...)...)
+	cmd.Dir = dir
+	return cmd
 }
 
 func script(dir, script string, args ...string) (*exec.Cmd, error) {

--- a/build/script_test.go
+++ b/build/script_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNodeExecutableCommandStructure(t *testing.T) {
-	cmd := nodeExecutableScript("/path/to/executable", "build", "some-arg")
+	cmd := nodeExecutableScript("root/dir", "/path/to/executable", "build", "some-arg")
 
 	if !reflect.DeepEqual(cmd.Args, []string{"/path/to/executable", "build", "some-arg"}) {
 		t.Errorf("Unexpected program arguments: %s", strings.Join(cmd.Args, " "))

--- a/packages/shopify-cli-extensions/src/build.ts
+++ b/packages/shopify-cli-extensions/src/build.ts
@@ -46,7 +46,10 @@ export function build({mode}: Options) {
       built = true;
       logResult(result);
     })
-    .catch((_e) => process.exit(1));
+    .catch((_e) => {
+      console.error('Error building extension: ', _e);
+      process.exit(1);
+    });
 }
 
 function getPlugins() {


### PR DESCRIPTION
When executing `serve` we found a couple of bugs:

- The GO Binary wasn't looking for the entry point at the correct path.
  - We've modified the path to include `extension.development.RootDir` as the working directory
  
- When failing to build, there was no feedback, the process just finishes.
  - We've added a `console.error` in case the build fails. That way the go part will receive and report the error. 