### PR TITLE
Use publicUrl instead of the request host when building websocket messages

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -49,7 +49,7 @@ func New(config *core.Config, apiRoot string) *ExtensionsApi {
 
 func (api *ExtensionsApi) sendUpdateEvent(extensions []core.Extension) {
 	api.notifyClients(func(rootUrl string) (message notification, err error) {
-		return api.getNotification("update", extensions, rootUrl)
+		return api.getNotification("update", extensions, api.publicUrl)
 	})
 }
 
@@ -252,6 +252,7 @@ func configureExtensionsApi(config *core.Config, router *mux.Router, apiRoot str
 		sync.Map{},
 		apiRoot,
 		sync.Map{},
+		config.PublicUrl + "/extensions/",
 	}
 
 	api.HandleFunc(strings.TrimSuffix(apiRoot, "/"), handlerWithCors(api.extensionsHandler))
@@ -318,7 +319,7 @@ func (api *ExtensionsApi) sendStatusUpdates(rw http.ResponseWriter, r *http.Requ
 		notifications <- update
 	}, closeConnection)
 
-	notification, err := api.getNotification("connected", api.Extensions, connection.rootUrl)
+	notification, err := api.getNotification("connected", api.Extensions, api.publicUrl)
 	if err != nil {
 		closeConnection(websocket.CloseNoStatusReceived, fmt.Sprintf("cannot send connected message, failed with error: %v", err))
 	}
@@ -461,7 +462,7 @@ func (api *ExtensionsApi) handleClientMessages(ws *websocketConnection) {
 
 		case "dispatch":
 			api.notifyClients(func(rootUrl string) (message notification, err error) {
-				return api.getDispatchNotification(jsonMessage.Data, rootUrl)
+				return api.getDispatchNotification(jsonMessage.Data, api.publicUrl)
 			})
 		}
 	}
@@ -590,6 +591,7 @@ type ExtensionsApi struct {
 	connections sync.Map
 	apiRoot     string
 	updates     sync.Map
+	publicUrl   string
 }
 
 type notification struct {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -313,9 +313,9 @@ func TestWebsocketNotify(t *testing.T) {
 	secondConnection.ReadJSON(&websocketMessage{})
 
 	expectedExtensions := []core.Extension{
-		getExpectedExtensionWithUrls(api.Extensions[0], server.URL),
-		getExpectedExtensionWithUrls(api.Extensions[1], server.URL),
-		getExpectedExtensionWithUrls(api.Extensions[2], server.URL),
+		getExpectedExtensionWithUrls(api.Extensions[0], api.publicUrl),
+		getExpectedExtensionWithUrls(api.Extensions[1], api.publicUrl),
+		getExpectedExtensionWithUrls(api.Extensions[2], api.publicUrl),
 	}
 
 	api.Notify(api.Extensions)
@@ -419,9 +419,9 @@ func TestWebsocketConnectionStartAndShutdown(t *testing.T) {
 	}
 
 	expectedExtensions := []core.Extension{
-		getExpectedExtensionWithUrls(api.Extensions[0], server.URL),
-		getExpectedExtensionWithUrls(api.Extensions[1], server.URL),
-		getExpectedExtensionWithUrls(api.Extensions[2], server.URL),
+		getExpectedExtensionWithUrls(api.Extensions[0], api.publicUrl),
+		getExpectedExtensionWithUrls(api.Extensions[1], api.publicUrl),
+		getExpectedExtensionWithUrls(api.Extensions[2], api.publicUrl),
 	}
 
 	if err := verifyWebsocketMessage(first_connection, "connected", api.Version, api.App, expectedExtensions, api.Store); err != nil {
@@ -462,9 +462,9 @@ func TestWebsocketConnectionClientClose(t *testing.T) {
 	}
 
 	expectedExtensions := []core.Extension{
-		getExpectedExtensionWithUrls(api.Extensions[0], server.URL),
-		getExpectedExtensionWithUrls(api.Extensions[1], server.URL),
-		getExpectedExtensionWithUrls(api.Extensions[2], server.URL),
+		getExpectedExtensionWithUrls(api.Extensions[0], api.publicUrl),
+		getExpectedExtensionWithUrls(api.Extensions[1], api.publicUrl),
+		getExpectedExtensionWithUrls(api.Extensions[2], api.publicUrl),
 	}
 
 	if err := verifyWebsocketMessage(first_connection, "connected", api.Version, api.App, expectedExtensions, api.Store); err != nil {
@@ -546,7 +546,7 @@ func TestWebsocketClientUpdateMatchingExtensionsEvent(t *testing.T) {
 	// First message received is the connected message which can be ignored
 	ws.ReadJSON(&websocketMessage{})
 
-	updatedExtensions := []core.Extension{getExpectedExtensionWithUrls(api.Extensions[0], server.URL)}
+	updatedExtensions := []core.Extension{getExpectedExtensionWithUrls(api.Extensions[0], api.publicUrl)}
 	updatedExtensions[0].Development.Hidden = true
 	updatedExtensions[0].Development.Status = "error"
 
@@ -641,7 +641,7 @@ func TestWebsocketClientUpdateBooleanValue(t *testing.T) {
 
 	<-time.After(duration)
 
-	updatedExtensions := []core.Extension{getExpectedExtensionWithUrls(api.Extensions[0], server.URL)}
+	updatedExtensions := []core.Extension{getExpectedExtensionWithUrls(api.Extensions[0], api.publicUrl)}
 	updatedExtensions[0].Development.Hidden = false
 
 	if err := verifyWebsocketMessage(ws, "update", api.Version, api.App, updatedExtensions, api.Store); err != nil {
@@ -753,14 +753,14 @@ func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
 			"assets": {
 			"main": {
 				"name": "main",
-				"url": "%v/extensions/00000000-0000-0000-0000-000000000000/assets/main.js",
+				"url": "%v00000000-0000-0000-0000-000000000000/assets/main.js",
 				"lastUpdated": 0
 			}
 			},
 			"development": {
 			"hidden": false,
 			"resource": {"url": ""},
-			"root": {"url": "%v/extensions/00000000-0000-0000-0000-000000000000"},
+			"root": {"url": "%v00000000-0000-0000-0000-000000000000"},
 			"localizationStatus": "",
 			"status": "success",
 			"resource": {"url": "cart/1234"}
@@ -776,7 +776,7 @@ func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
 				"networkAccess": false
 			}
 		}
-		]`, server.URL, server.URL)
+		]`, api.publicUrl, api.publicUrl)
 
 	match, err := isEqualJSON(expectedExtensions, string(extensions))
 	if err != nil {
@@ -950,8 +950,8 @@ func getHTMLResponse(api *ExtensionsApi, t *testing.T, host, requestUri string) 
 }
 
 func getExpectedExtensionWithUrls(extension core.Extension, host string) core.Extension {
-	extension.Development.Root.Url = fmt.Sprintf("%s/extensions/%s", host, extension.UUID)
-	extension.Assets["main"] = core.Asset{Name: "main", Url: fmt.Sprintf("%s/extensions/%s/assets/main.js", host, extension.UUID)}
+	extension.Development.Root.Url = fmt.Sprintf("%s%s", host, extension.UUID)
+	extension.Assets["main"] = core.Asset{Name: "main", Url: fmt.Sprintf("%s%s/assets/main.js", host, extension.UUID)}
 	return extension
 }
 


### PR DESCRIPTION
### Why
We need to use the go binary behind a reverse proxy so we can serve both the web app and the extensions at the same time under the same ngrok tunnel.
That means that the websocket is also behind a localhost proxy, this was causing the go binary to think that the remote host is `localhost` (because all connections were received from the localhost proxy).

### Solution
Instead of using the `connection.rootUrl` to build the extensions URLs, we use the `publicUrl` set in the config yml file. This way we force the go server to use the tunnel URL ignoring the proxy host.


Looking forward for any feedback on this solution or if you think there could be a better approach :)