### PR TITLE
Adding pos_ui_extensions template for CLI3

### DIFF
--- a/create/templates/projects/pos_ui_extension_next/shopify.ui.extension.toml.tpl
+++ b/create/templates/projects/pos_ui_extension_next/shopify.ui.extension.toml.tpl
@@ -1,0 +1,6 @@
+{{- template "shared/shopify.ui.extension.toml" . }}
+
+extension_points = [
+  'Retail::SmartGrid::Tile',
+  'Retail::SmartGrid::Modal'
+]

--- a/create/templates/projects/pos_ui_extension_next/src/index.tpl
+++ b/create/templates/projects/pos_ui_extension_next/src/index.tpl
@@ -1,0 +1,5 @@
+{{- if .Development.UsesReact -}}
+{{ template "shared/pos_ui_extension/react.js" . }}
+{{- else -}}
+{{ template "shared/pos_ui_extension/javascript.js" . }}
+{{- end -}}


### PR DESCRIPTION
Resolves #329

Problem: Created a version for each of the templates with the `_next` suffix for `pos_ui_extension` to indicate that they are for the new CLI 3.0. Those templates contain changes to accommodate them to the new development experience.