### PR TITLE
Move onClick handler calls to <td> instead of <tr>

### DIFF
--- a/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
+++ b/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import React, {MouseEvent, useCallback, useState} from 'react';
 import {useI18n} from '@shopify/react-i18n';
 import {ExtensionPayload} from '@shopify/ui-extensions-server-kit';
@@ -34,7 +36,9 @@ export function ExtensionRow({
 
   const handleSelect = useCallback(
     (event?: MouseEvent) => {
-      if (event) event.stopPropagation();
+      if (event) {
+        event.stopPropagation();
+      }
       onSelect(extension);
     },
     [extension, onSelect],
@@ -47,7 +51,6 @@ export function ExtensionRow({
   return (
     <tr
       className={styles.DevToolRow}
-      onClick={handleSelect}
       onFocus={() => {
         setFocus(true);
       }}
@@ -60,9 +63,13 @@ export function ExtensionRow({
       <td>
         <Checkbox label="" checked={selected} onChange={() => handleSelect()} />
       </td>
-      <td className={textClass}>{extension.title}</td>
-      <td className={textClass}>{extension.type}</td>
-      <td>
+      <td onClick={handleSelect} className={textClass}>
+        {extension.title}
+      </td>
+      <td onClick={handleSelect} className={textClass}>
+        {extension.type}
+      </td>
+      <td onClick={handleSelect}>
         <span className={`${styles.Status} ${statusClass}`}>
           {i18n.translate(`statuses.${status}`)}
         </span>


### PR DESCRIPTION
The problem with the `Checkbox` is not due to propagation. The `<tr>` element's `onClick` handler and `Checkbox` element's `onChange` handler both toggle the checkbox. This works well when the table row is clicked anywhere except the checkbox itself. When the checkbox is clicked, both the `<tr>` and the `Checkbox` explicitly fire mouse click events, causing the checkbox to become toggled twice in quick succession.

The `<tr>` toggling behavior is a convenience and removing it is one possible solution. Another possible solution is to remove the `onChange` handler from the `Checkbox` itself, but prevents it from being manipulated with the keyboard. The solution in this PR is to remove the `<tr>` `onClick` behavior and add it to each of the `<td>` elements (except the one that contains the `Checkbox`). This is is an imperfect solution, but preserves the keyboard behavior and most of the row toggling behavior.