### PR TITLE
updated pixel runtime values from sandbox/unsandbox to strict/lax

### DIFF
--- a/create/templates/projects/web_pixel_extension/extension.config.yml
+++ b/create/templates/projects/web_pixel_extension/extension.config.yml
@@ -1,4 +1,4 @@
-runtime_context: sandbox
+runtime_context: strict
 version: "1"
 configuration:
   type: object

--- a/create/templates/projects/web_pixel_extension_next/shopify.ui.extension.toml.tpl
+++ b/create/templates/projects/web_pixel_extension_next/shopify.ui.extension.toml.tpl
@@ -1,5 +1,5 @@
 {{ template "shared/shopify.ui.extension.toml" . }}
-runtime_context = "sandbox"
+runtime_context = "strict"
 version = "1"
 
 [configuration]


### PR DESCRIPTION
EPIC: https://github.com/Shopify/ce-customer-behaviour/issues/984

the values for pixel runtime context should be 'strict' and 'lax'

This pr updates the templates for web pixel to default to strict