### PR TITLE
Fix Checkbox double-toggle on Dev Console

### DIFF
--- a/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
+++ b/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
@@ -34,9 +34,7 @@ export function ExtensionRow({
 
   const handleRowSelect = useCallback(
     (event?: MouseEvent) => {
-      if (event) {
-        event.stopPropagation();
-      }
+      event?.stopPropagation();
 
       // Ignore the case of the checkbox itself being selected, which is handled by handleCheckBoxSelect
       const target = event?.target as Element;

--- a/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
+++ b/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
@@ -32,13 +32,30 @@ export function ExtensionRow({
     development: {hidden, status},
   } = extension;
 
-  const handleSelect = useCallback(
+  const handleRowSelect = useCallback(
     (event?: MouseEvent) => {
-      if (event) event.stopPropagation();
-      onSelect(extension);
+      if (event) {
+        event?.stopPropagation();
+      }
+
+      // Ignore the case of the checkbox itself being selected, which is handled by handleCheckBoxSelect
+      const target = event?.target as Element;
+      if (!target.className.match(/Polaris-Checkbox/)) {
+        onSelect(extension);
+      }
     },
     [extension, onSelect],
   );
+
+  const handleCheckboxSelect = useCallback(
+    (newChecked?: boolean) => {
+      if (newChecked !== selected) {
+        onSelect(extension);
+      }
+    },
+    [selected, onSelect, extension],
+  );
+
   const [isFocus, setFocus] = useState(false);
 
   const textClass = hidden ? styles.Hidden : undefined;
@@ -47,7 +64,7 @@ export function ExtensionRow({
   return (
     <tr
       className={styles.DevToolRow}
-      onClick={handleSelect}
+      onClick={handleRowSelect}
       onFocus={() => {
         setFocus(true);
       }}
@@ -58,7 +75,7 @@ export function ExtensionRow({
       onMouseLeave={onClearHighlight}
     >
       <td>
-        <Checkbox label="" checked={selected} onChange={() => handleSelect()} />
+        <Checkbox label="" checked={selected} onChange={handleCheckboxSelect} />
       </td>
       <td className={textClass}>{extension.title}</td>
       <td className={textClass}>{extension.type}</td>

--- a/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
+++ b/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
@@ -32,26 +32,12 @@ export function ExtensionRow({
     development: {hidden, status},
   } = extension;
 
-  const handleRowSelect = useCallback(
+  const handleSelect = useCallback(
     (event?: MouseEvent) => {
-      event?.stopPropagation();
-
-      // Ignore the case of the checkbox itself being selected, which is handled by handleCheckBoxSelect
-      const target = event?.target as Element;
-      if (!target.className.match(/Polaris-Checkbox/)) {
-        onSelect(extension);
-      }
+      if (event) event.stopPropagation();
+      onSelect(extension);
     },
     [extension, onSelect],
-  );
-
-  const handleCheckboxSelect = useCallback(
-    (newChecked?: boolean) => {
-      if (newChecked !== selected) {
-        onSelect(extension);
-      }
-    },
-    [selected, onSelect, extension],
   );
 
   const [isFocus, setFocus] = useState(false);
@@ -62,7 +48,7 @@ export function ExtensionRow({
   return (
     <tr
       className={styles.DevToolRow}
-      onClick={handleRowSelect}
+      onClick={handleSelect}
       onFocus={() => {
         setFocus(true);
       }}
@@ -73,7 +59,12 @@ export function ExtensionRow({
       onMouseLeave={onClearHighlight}
     >
       <td>
-        <Checkbox label="" checked={selected} onChange={handleCheckboxSelect} />
+        {
+          // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+          <div onClick={(event) => event.stopPropagation()}>
+            <Checkbox label="" checked={selected} onChange={() => handleSelect()} />
+          </div>
+        }
       </td>
       <td className={textClass}>{extension.title}</td>
       <td className={textClass}>{extension.type}</td>

--- a/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
+++ b/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
@@ -35,7 +35,7 @@ export function ExtensionRow({
   const handleRowSelect = useCallback(
     (event?: MouseEvent) => {
       if (event) {
-        event?.stopPropagation();
+        event.stopPropagation();
       }
 
       // Ignore the case of the checkbox itself being selected, which is handled by handleCheckBoxSelect


### PR DESCRIPTION
Split row selection and checkbox selection handler logic so that both are not triggered concurrently when the checkbox is toggled.