### PR TITLE
Fix POS extension scaffolding

### DIFF
--- a/create/templates/shared/pos_ui_extension/react.js
+++ b/create/templates/shared/pos_ui_extension/react.js
@@ -6,7 +6,7 @@ const Tile = () => {
 
   return(
     <>
-      <Tile title="My app" subtitle="Welcome to my react app" enabled onPress={() => {api.navigation.navigateToFullScreenModal()}} />
+      <Tile title="My app" subtitle="Welcome to my react app" enabled />
     </>
   );
 }


### PR DESCRIPTION
⚠️ I know this fix is not the right solution, just wanted to point out the issue.

Creating POS extensions doesn't work unless I remove this part of the template. Even although this change is only in the react template, it was also making the javascript one fail.

Maybe someone with more context know best what the actual issue is here?