### PR TITLE
Remove next-step templates

### DIFF
--- a/create/templates/shared/checkout_post_purchase/next-steps.txt
+++ b/create/templates/shared/checkout_post_purchase/next-steps.txt
@@ -1,6 +1,0 @@
-
-🔭 > If this is the first time you're testing a Post Purchase extension, please install
-🔭 > the browser extension from https://github.com/Shopify/post-purchase-devtools/releases.
-
-🔭 > Once installed, simply enter your extension URL
-🔭 > {{.IntegrationContext.PublicUrl}}/extensions/{{.Extension.UUID}}.

--- a/create/templates/shared/checkout_ui_extension/next-steps.txt
+++ b/create/templates/shared/checkout_ui_extension/next-steps.txt
@@ -1,7 +1,0 @@
-
-🔭 > If this is first time you are testing the extension,
-🔭 > please login to your development store first by visiting
-🔭 > https://{{.IntegrationContext.Store}}/password
-
-🔭 > To create a checkout and test your extension please visit the following URL:
-🔭 > {{.IntegrationContext.PublicUrl}}/extensions/{{.Extension.UUID}}

--- a/create/templates/shared/pos_ui_extension/next-steps.txt
+++ b/create/templates/shared/pos_ui_extension/next-steps.txt
@@ -1,3 +1,0 @@
-
-🔭 > To test your extension please visit the following URL:
-🔭 > {{.IntegrationContext.PublicUrl}} and click on the QR code and scan it with your phone

--- a/create/templates/shared/product_subscription/next-steps.txt
+++ b/create/templates/shared/product_subscription/next-steps.txt
@@ -1,3 +1,0 @@
-
-🔭 > To test your extension please visit the following URL:
-🔭 > {{.IntegrationContext.PublicUrl}}/extensions/{{.Extension.UUID}}


### PR DESCRIPTION
We want to control how extensions URLs are presented to the users from the CLI. In order to provide a consistent output with the rest of the CLI as well as having more flexibility to provide detailed instructions without being lost in the logs (since we serve frontend, backend and extensions at the same time, it gets messy)

This PR removes all `next-step` templates and that info will be handled by CLI now.