### PR TITLE
Expose Dev Console url in Server response

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -17,7 +17,7 @@ const (
 	POS          string = "pos"
 )
 
-func NewExtensionService(config *Config, apiRoot string) *ExtensionService {
+func NewExtensionService(config *Config) *ExtensionService {
 	// Create a copy so we don't mutate the configs
 	extensions := []Extension{}
 	for _, extension := range config.Extensions {
@@ -45,11 +45,13 @@ func NewExtensionService(config *Config, apiRoot string) *ExtensionService {
 	app["api_key"] = config.App.ApiKey
 
 	service := ExtensionService{
-		App:        app,
-		Version:    "3",
-		Extensions: extensions,
-		Port:       config.Port,
-		Store:      config.Store,
+		App:            app,
+		Version:        "4",
+		Extensions:     extensions,
+		Port:           config.Port,
+		Store:          config.Store,
+		ApiRoot:        "/extensions",
+		DevConsolePath: "/dev-console",
 	}
 
 	return &service
@@ -79,12 +81,14 @@ type IntegrationContext struct {
 }
 
 type ExtensionService struct {
-	App        App
-	Extensions []Extension
-	Port       int
-	Store      string
-	Version    string
-	PublicUrl  string
+	App            App
+	Extensions     []Extension
+	Port           int
+	Store          string
+	Version        string
+	PublicUrl      string
+	ApiRoot        string `json:"-" yaml:"-"`
+	DevConsolePath string `json:"-" yaml:"-"`
 }
 
 type Localization struct {

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func (cli *CLI) create(args ...string) {
 }
 
 func (cli *CLI) serve(args ...string) {
-	api := api.New(cli.config, "/extensions/")
+	api := api.New(cli.config)
 
 	for _, extension := range cli.config.Extensions {
 		go build.Watch(extension, cli.config.IntegrationContext, func(result build.Result) {

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/APIClient.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/APIClient.ts
@@ -4,7 +4,7 @@ export class APIClient implements ExtensionServer.API.Client {
   constructor(public url: string, public surface?: Surface) {}
 
   async extensions(): Promise<ExtensionServer.API.ExtensionsResponse> {
-    const response = await fetch(`${this.url}/extensions`);
+    const response = await fetch(this.url);
     const dto: ExtensionServer.API.ExtensionsResponse = await response.json();
     const filteredExtensions = dto.extensions.filter(
       (extension) => !this.surface || extension.surface === this.surface,
@@ -13,7 +13,7 @@ export class APIClient implements ExtensionServer.API.Client {
   }
 
   async extensionById(id: string): Promise<ExtensionServer.API.ExtensionResponse> {
-    const response = await fetch(`${this.url}/extensions/${id}`);
+    const response = await fetch(`${this.url}/${id}`);
     const dto: ExtensionServer.API.ExtensionResponse = await response.json();
     return dto;
   }

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/types.ts
@@ -129,6 +129,7 @@ declare global {
         app: App;
         root: ResourceURL;
         socket: ResourceURL;
+        devConsole: ResourceURL;
         store: string;
         version: string;
       }


### PR DESCRIPTION
### Changes

- Fix issue where the payload for websocket messages was returning the extension development url incorrectly when connecting to the websocket on localhost. This was hardcoded to return the public url which errors out when the public url hasn't been set. We should be consistent and return the current requested url like we do for the JSON response.
   **Before**
   https://user-images.githubusercontent.com/29458473/173088734-b0dad009-c36d-410f-beeb-78284c0bd078.mov

   **After**
   https://user-images.githubusercontent.com/29458473/173089050-53053165-b0fd-4235-bcf7-283d06a04a33.mov
- Clean up tests so that configured values like the apiRoot and extension uuid is not hardcoded in the test. This makes it easier to distinguish between values we expect to be passed in externally vs. hardcoded ones.
- Expose Dev Console url in ExtensionsResponse TS interface
- Bump Api Service version to 4
- Move API Service configs to a single place
- Remove trailing slash on the apiRoot

### Tophat
2. Run `make build; make run serve testdata/extension.config.yml`
3. Open http://localhost:8000
4. Click on the link to any extension
5. Verify that the tunnel error message appears
6. Open http://localhost:8000/extensions
7. Verify that the JSON response contains `{devConsole: {url: "http://localhost:8000/extensions/dev-console"}`
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/29458473/173087208-8f147eab-c069-4099-b341-15c3c4f71525.png">
