### PR TITLE
Fix issue where partial extension updates was forcing boolean values to be false

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -615,7 +615,7 @@ func TestWebsocketClientUpdateMatchingExtensionsEvent(t *testing.T) {
 	unchangedExtensionUUID := api.Extensions[1].UUID
 
 	updatedExtensions := []core.Extension{getExpectedExtensionWithUrls(api.Extensions[0], rootUrl)}
-	updatedExtensions[0].Development.Hidden = true
+	*updatedExtensions[0].Development.Hidden = true
 	updatedExtensions[0].Development.Status = "error"
 
 	duration := 1 * time.Second
@@ -642,7 +642,7 @@ func TestWebsocketClientUpdateMatchingExtensionsEvent(t *testing.T) {
 
 	getSingleExtensionJSONResponse(api, t, server.URL, updateExtensionUUID, &updated)
 
-	if updated.Extension.Development.Hidden != true {
+	if *updated.Extension.Development.Hidden != true {
 		t.Errorf("expected response for extension %s Development.Hidden to be true but got %v", updateExtensionUUID, updated.Extension.Development.Hidden)
 	}
 
@@ -650,7 +650,7 @@ func TestWebsocketClientUpdateMatchingExtensionsEvent(t *testing.T) {
 		t.Errorf("expected response for extension %s Development.Status to be \"error\" but got %v", updateExtensionUUID, updated.Extension.Development.Status)
 	}
 
-	if apiUpdatedExtension.Development.Hidden != true {
+	if *apiUpdatedExtension.Development.Hidden != true {
 		t.Errorf("expected API extension %s Development.Hidden to be true  but got %v", updateExtensionUUID, apiUpdatedExtension.Development.Hidden)
 	}
 
@@ -662,7 +662,7 @@ func TestWebsocketClientUpdateMatchingExtensionsEvent(t *testing.T) {
 	unchanged := singleExtensionResponse{}
 	getSingleExtensionJSONResponse(api, t, server.URL, unchangedExtensionUUID, &unchanged)
 
-	if unchanged.Extension.Development.Hidden != false {
+	if *unchanged.Extension.Development.Hidden != false {
 		t.Errorf("expected response for extension %s Development.Hidden to be unchanged but got %v", unchangedExtensionUUID, unchanged.Extension.Development.Hidden)
 	}
 
@@ -670,7 +670,7 @@ func TestWebsocketClientUpdateMatchingExtensionsEvent(t *testing.T) {
 		t.Errorf("expected response for extension %s Development.Status to be unchanged but got %v", unchangedExtensionUUID, unchanged.Extension.Development.Status)
 	}
 
-	if apiUnchangedExtension.Development.Hidden != false {
+	if *apiUnchangedExtension.Development.Hidden != false {
 		t.Errorf("expected API extension %s Development.Hidden to be unchanged but got %v", unchangedExtensionUUID, apiUpdatedExtension.Development.Hidden)
 	}
 
@@ -683,7 +683,7 @@ func TestWebsocketClientUpdateBooleanValue(t *testing.T) {
 	api := New(config)
 	updateExtension := api.Extensions[0]
 
-	updateExtension.Development.Hidden = true
+	*updateExtension.Development.Hidden = true
 
 	server := httptest.NewServer(api)
 
@@ -718,7 +718,7 @@ func TestWebsocketClientUpdateBooleanValue(t *testing.T) {
 	rootUrl := fmt.Sprintf("%s%s", server.URL, api.ApiRoot)
 
 	updatedExtensions := []core.Extension{getExpectedExtensionWithUrls(api.Extensions[0], rootUrl)}
-	updatedExtensions[0].Development.Hidden = false
+	*updatedExtensions[0].Development.Hidden = false
 
 	if err := verifyWebsocketMessage(ws, "update", api.Version, api.App, updatedExtensions, api.Store); err != nil {
 		t.Error(err)
@@ -728,10 +728,10 @@ func TestWebsocketClientUpdateBooleanValue(t *testing.T) {
 	updated := singleExtensionResponse{}
 	getSingleExtensionJSONResponse(api, t, server.URL, updateExtension.UUID, &updated)
 
-	if updated.Extension.Development.Hidden != false {
+	if *updated.Extension.Development.Hidden != false {
 		t.Errorf("expected response for extension %s Development.Hidden to be false but got %v", updateExtension.UUID, updated.Extension.Development.Hidden)
 	}
-	if apiUpdatedExtension.Development.Hidden != false {
+	if *apiUpdatedExtension.Development.Hidden != false {
 		t.Errorf("expected API extension %s Development.Hidden to be false but got %v", updateExtension.UUID, apiUpdatedExtension.Development.Hidden)
 	}
 }

--- a/core/core.go
+++ b/core/core.go
@@ -37,6 +37,14 @@ func NewExtensionService(config *Config) *ExtensionService {
 			extension.Surface = GetSurface(&extension)
 		}
 
+		if extension.Capabilities.NetworkAccess == nil {
+			extension.Capabilities.NetworkAccess = NewBoolPointer(false)
+		}
+
+		if extension.Development.Hidden == nil {
+			extension.Development.Hidden = NewBoolPointer(false)
+		}
+
 		extensions = append(extensions, extension)
 	}
 	// TODO: Improve this when we need to read more app configs,
@@ -98,7 +106,7 @@ type Localization struct {
 }
 
 type Capabilities struct {
-	NetworkAccess bool `json:"networkAccess" yaml:"network_access"`
+	NetworkAccess *bool `json:"networkAccess" yaml:"network_access"`
 }
 
 type Extension struct {
@@ -150,7 +158,7 @@ type Development struct {
 	Renderer           Renderer          `json:"-" yaml:"renderer,omitempty"`
 	Root               Url               `json:"root" yaml:"root,omitempty"`
 	RootDir            string            `json:"-" yaml:"root_dir,omitempty"`
-	Hidden             bool              `json:"hidden" yaml:"-"`
+	Hidden             *bool             `json:"hidden" yaml:"-"`
 	Status             string            `json:"status" yaml:"-"`
 	LocalizationStatus string            `json:"localizationStatus" yaml:"-"`
 	Template           string            `json:"-" yaml:"template,omitempty"`
@@ -209,6 +217,12 @@ func GetSurface(extension *Extension) string {
 		return POS
 	}
 	return Admin
+}
+
+func NewBoolPointer(boolState bool) *bool {
+	boolPointer := new(bool)
+	*boolPointer = boolState
+	return boolPointer
 }
 
 type Fragment map[string]interface{}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -46,8 +46,8 @@ extensions:
 		t.Errorf("invalid name - expected Alternate Name got %s", extension.Name)
 	}
 
-	if extension.Capabilities.NetworkAccess != true {
-		t.Errorf("invalid value for Capabilities - expected network_access got %t", extension.Capabilities.NetworkAccess)
+	if *extension.Capabilities.NetworkAccess != true {
+		t.Errorf("invalid value for Capabilities - expected network_access got %t", *extension.Capabilities.NetworkAccess)
 	}
 }
 

--- a/packages/dev-console-app/src/App.tsx
+++ b/packages/dev-console-app/src/App.tsx
@@ -13,7 +13,7 @@ const host = (import.meta.env.VITE_WEBSOCKET_HOST as string) || location.host;
 const surface = new URLSearchParams(location.search).get('surface');
 const extensionServerOptions = {
   connection: {
-    url: `${protocol}//${host}/extensions/`,
+    url: `${protocol}//${host}/extensions`,
   },
   surface: isValidSurface(surface) ? surface : undefined,
 };


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify-cli-extensions/issues/203

There is a quirk in Go where a boolean that has not been initialized is equivalent to `false`. When an extension update
event comes in with partial data as all boolean values that have not been initialized is defaulted to `false`. This cause a strange bug where `true` boolean values are overwritten by non-initialized boolean as `false`.

This is fixed by using a pointer to a boolean to distinguish between a boolean that has been set to `false` vs. one that has not been set.

**Before**

https://user-images.githubusercontent.com/29458473/173366406-ffd9bbdf-d25e-4e17-a498-1578cec0c12a.mov

**After**

https://user-images.githubusercontent.com/29458473/173366466-2a0c439d-c9e9-42ce-8ef9-62c2eae4289d.mov

### Tophat

1. Modify `testdata/extension.config.yml` so that Checkout UI Extension to add the following:
```diff
extensions:
  - uuid: 00000000-0000-0000-0000-000000000000
    type: checkout_ui_extension
    title: Checkout UI Test Extension
    metafields:
      - namespace: my-namespace
        key: my-key
    development:
          root_dir: 'tmp/checkout_ui_extension'
          build_dir: 'build'
          template: 'typescript-react'
          renderer:
            name: '@shopify/checkout-ui-extensions'
            version: '^0.14.0'
          entries:
            main: 'src/index.tsx'
          resource:
            url: 'cart/1234'
+        capabilities:
+          network_access: true
```
3. Run `make build; make run serve testdata/extension.config.yml`
4. Open Chrome and the Dev Tools Network inspector, filter by WS and click on `/extensions`
5.  Go to http://localhost:8000
1. Verify that the "connected" message from the websocket shows `capabilities.accessNetwork: true` for the Checkout UI Extension
   <img width="1393" alt="image" src="https://user-images.githubusercontent.com/29458473/173369156-4b484f63-7b56-401e-9248-6228c3bf7fa8.png">
1. Open `tmp/checkout_ui_extension/src/index.tsx` and make some changes to the code and save the file
1. Verify that the "update" message shows `capabilities.accessNetwork: true` for the Checkout UI Extension
   <img width="1395" alt="image" src="https://user-images.githubusercontent.com/29458473/173368654-aa9d1377-7d03-4e72-89e3-07de58b36b46.png">

6. In the Dev Console to the "hide" icon to hide Checkout UI Extension
7. Open `tmp/checkout_ui_extension/src/index.tsx` and make some changes to the code and save the file
8. Verify that the the Dev Console still shows the Checkout UI Extension as hidden

