### PR TITLE
Exclude all legal comments when building extensions

### DIFF
--- a/packages/shopify-cli-extensions/src/build.ts
+++ b/packages/shopify-cli-extensions/src/build.ts
@@ -32,7 +32,7 @@ export function build({mode}: Options) {
       '.js': 'jsx',
     },
     logLevel: isDevelopment ? 'silent' : 'info',
-    legalComments: isDevelopment ? 'none' : 'linked',
+    legalComments: 'none',
     minify: !isDevelopment,
     outdir: buildDir,
     plugins: getPlugins(),


### PR DESCRIPTION
We need to ensure legal comments are preserved in order to not break licensing agreements when using open source libraries. Previously we were linking to a separate license text file but this is not easily accessible when the extension is uploaded to the CDN. Therefore the best solution is to preserve the license comments in the source code.