### PR TITLE
Trap & kill `make serve-dev` process group

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -27,17 +26,6 @@ func init() {
 }
 
 func main() {
-	go func() {
-		sigchan := make(chan os.Signal)
-		signal.Notify(sigchan, syscall.SIGINT, syscall.SIGKILL, syscall.SIGTERM)
-		<-sigchan
-		log.Println("Program killed !")
-
-		// do last actions and wait for all write operations to end
-
-		os.Exit(0)
-	}()
-
 	cli := CLI{}
 	cmd, args := os.Args[1], os.Args[2:]
 


### PR DESCRIPTION
`Makefile` sets a trap so that when the `make serve-dev ...` process is terminated using `kill`, the entire process group is terminated. This prevents `kill` from leaving orphaned processes. However, this is only a partial solution, as killing a descendant process will not exhibit the same behavior.

https://user-images.githubusercontent.com/4490738/173621861-629229e4-4342-4688-a269-ba8615c293ac.mp4


