### PR TITLE
Remove server available output line

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,9 +122,7 @@ func (cli *CLI) serve(args ...string) {
 		server.Shutdown(ctx)
 	})
 
-	if cli.config.PublicUrl != "" {
-		fmt.Printf("Shopify CLI Extensions Server is now available at %s\n", cli.config.PublicUrl)
-	} else {
+	if cli.config.PublicUrl == "" {
 		fmt.Printf("Shopify CLI Extensions Server is now available at http://localhost:%d/\n", cli.config.Port)
 	}
 


### PR DESCRIPTION
Removed the `Shopify CLI Extensions Server is now available at https://0818-79-116-18-6.ngrok.io` line.

The server can't be accessed via that URL when served from the CLI so it doesn't make sense. We can talk about printing a different copy in case we want to have a link directly to the dev-console.

Left the `localhost` copy because when not run from CLI it might be useful.

