### PR TITLE
Renamed the deep link url parameter for POS

### DIFF
--- a/packages/dev-console-app/src/QRCodeModal/QRCodeModal.test.tsx
+++ b/packages/dev-console-app/src/QRCodeModal/QRCodeModal.test.tsx
@@ -72,7 +72,7 @@ describe('QRCodeModal', () => {
     );
 
     expect(container?.find(QRCode)?.prop('value')).toStrictEqual(
-      `com.shopify.pos://pos-ui-extensions?scriptUrl=${extension.development.root.url}`,
+      `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}`,
     );
   });
 });

--- a/packages/dev-console-app/src/QRCodeModal/QRCodeModal.tsx
+++ b/packages/dev-console-app/src/QRCodeModal/QRCodeModal.tsx
@@ -52,7 +52,7 @@ export function QRCodeContent(props: Pick<QRCodeModalProps, 'extension'>) {
     }
 
     if (extension.surface === 'pos') {
-      return `com.shopify.pos://pos-ui-extensions?scriptUrl=${extension.development.root.url}`;
+      return `com.shopify.pos://pos-ui-extensions?url=${extension.development.root.url}`;
     } else {
       return `https://${state.store}/admin/extensions-dev/mobile?url=${extension.development.root.url}`;
     }


### PR DESCRIPTION
The POS client expects a different parameter name for extension deep links. Renamed it from _scriptUrl_ to _url_. Resolves #348.