### PR TITLE
Make default extension more visually noticeable

### DIFF
--- a/create/templates/shared/checkout_ui_extension/javascript.js
+++ b/create/templates/shared/checkout_ui_extension/javascript.js
@@ -1,9 +1,9 @@
-import { extend, Text } from "@shopify/checkout-ui-extensions";
+import { extend, Banner } from "@shopify/checkout-ui-extensions";
 
 extend("Checkout::Dynamic::Render", (root, { extensionPoint, i18n }) => {
   root.appendChild(
     root.createComponent(
-      Text,
+      Banner,
       {},
       i18n.translate('welcome', {extensionPoint})
     )

--- a/create/templates/shared/checkout_ui_extension/react.js
+++ b/create/templates/shared/checkout_ui_extension/react.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import {useExtensionApi, render, Text} from '@shopify/checkout-ui-extensions-react';
+import {useExtensionApi, render, Banner} from '@shopify/checkout-ui-extensions-react';
 
 render('Checkout::Dynamic::Render', () => <App />);
 
 function App() {
   const {extensionPoint, i18n} = useExtensionApi();
-  return <Text>{i18n.translate('welcome', {extensionPoint})}</Text>;
+  return <Banner>{i18n.translate('welcome', {extensionPoint})}</Banner>;
 }


### PR DESCRIPTION
This PR makes the default Checkout UI extension more visually noticeable inside the Checkout UI. The previous layout was too easy to miss and led to confusion if the extension was showing up or not.

Fixes https://github.com/Shopify/ui-extensions/issues/326

Before:

<img width="616" alt="Screenshot 2022-06-15 at 13 37 54" src="https://user-images.githubusercontent.com/1062408/173818438-20143852-7d12-4fdd-b5aa-3c9ca6376c58.png">

After:

<img width="596" alt="Screenshot 2022-06-15 at 13 37 21" src="https://user-images.githubusercontent.com/1062408/173818454-264a63ce-9fde-4638-94f2-140eb8c242e4.png">
