### PR TITLE
Set API version back to 3 as there has been no breaking changes

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -62,7 +62,7 @@ func TestInitializeWithProvidedConfigOptions(t *testing.T) {
 		t.Errorf("Expected 3 extension got %d", len(api.Extensions))
 	}
 
-	if api.Version != "4" {
+	if api.Version != "3" {
 		t.Errorf("expect service version to be 4 but got %s", api.Version)
 	}
 

--- a/core/core.go
+++ b/core/core.go
@@ -42,7 +42,7 @@ func NewExtensionService(config *Config) *ExtensionService {
 
 	service := ExtensionService{
 		App:            app,
-		Version:        "4",
+		Version:        "3",
 		Extensions:     extensions,
 		Port:           config.Port,
 		Store:          config.Store,


### PR DESCRIPTION
Given that there has been no breaking changes to the API, we do not need to bump the API version. We need to set this back to "3" to avoid issues on Mobile thinking it cannot read the manifest provided by the API even though it is compatible