### PR TITLE
Fix extensions by allowing checkout to send an ngrok header

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -544,7 +544,7 @@ func withCors(h http.Handler) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Set("Access-Control-Allow-Origin", "*")
 		rw.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		rw.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+		rw.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, ngrok-skip-browser-warning")
 		h.ServeHTTP(rw, r)
 	}
 }


### PR DESCRIPTION
See https://github.com/Shopify/checkout-web/issues/11653

Allow an ngrok header to dismiss their intersitial which was preventing extensions from loading extensions from loading.

🎩 instructions

Create the equivalent of [`yarn dev` to preview an extension](https://shopify-dev-staging2.shopifycloud.com/apps/checkout/custom-fields/getting-started#step-2-preview-your-extension) using this version of `shopify-cli-extensions`.

Start this spin instance:

```bash
spin up -n ngrok-fix - << 'END'
---             
schema: v1
extend: checkout-ui-extension-dev
repos:
  - checkout-web:
      branch: kumar-ngrok-workaround
END
```

* From `spin open`, click to open a new checkout
* Use `?dev=<extension-server>` to install an extension