### PR TITLE
use the useTranslate hook in the react scaffold

### DIFF
--- a/create/templates/shared/checkout_ui_extension/react.js
+++ b/create/templates/shared/checkout_ui_extension/react.js
@@ -1,9 +1,15 @@
 import React from 'react';
-import {useExtensionApi, render, Banner} from '@shopify/checkout-ui-extensions-react';
+import {
+  useExtensionApi,
+  render,
+  Banner,
+  useTranslate,
+} from '@shopify/checkout-ui-extensions-react';
 
 render('Checkout::Dynamic::Render', () => <App />);
 
 function App() {
-  const {extensionPoint, i18n} = useExtensionApi();
-  return <Banner>{i18n.translate('welcome', {extensionPoint})}</Banner>;
+  const {extensionPoint} = useExtensionApi();
+  const translate = useTranslate();
+  return <Banner>{translate('welcome', {extensionPoint})}</Banner>;
 }


### PR DESCRIPTION
Updates the React extension scaffold to use the `useTranslate` hook for translations.

Closes: https://github.com/Shopify/shopify-cli-extensions/issues/362