### PR TITLE
log an error without locales directory

### DIFF
--- a/build/localization.go
+++ b/build/localization.go
@@ -130,7 +130,12 @@ func reportAndUpdateLocalizationStatus(result Result, report ResultHandler) {
 func WatchLocalization(ctx context.Context, extension core.Extension, report ResultHandler) {
 	directory := filepath.Join(".", extension.Development.RootDir, "locales")
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
-		// The extension does not have a locales directory.
+		msg := fmt.Sprintf(
+			"extension must provide a locales directory at: ./%s",
+			directory,
+		)
+		reportAndUpdateLocalizationStatus(Result{false, msg, extension}, report)
+
 		return
 	}
 


### PR DESCRIPTION
resolves https://github.com/Shopify/checkout-web/issues/11552

## What is this

when a `locales` folder is not present no translations will be present in the extension causing errors within checkout-web. This is required and expected.

## 🎩 

* have a working extension
* delete your `extensions/my_extension_name/locales` directory
* build the go binary and copy to where CLI3 references it internally: `$ go build && cp ./shopify-cli-extensions /Users/${your_name_here}/Library/Caches/shopify-cli-nodejs/vendor/binaries/extensions//v0.20.2-darwin-arm64`
* `yarn dev`
* server should log an error to stderr