### PR TITLE
Add support for external type used to display extensions information

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -86,6 +86,10 @@ func normalizeConfig(config *Config) {
 		if config.Extensions[index].Development.Hidden == nil {
 			config.Extensions[index].Development.Hidden = NewBoolPointer(false)
 		}
+
+		if config.Extensions[index].ExternalType == "" {
+			config.Extensions[index].ExternalType = config.Extensions[index].Type
+		}
 	}
 
 }
@@ -139,6 +143,7 @@ type Extension struct {
 	Localization    *Localization    `json:"localization" yaml:"-"`
 	Metafields      []Metafield      `json:"metafields" yaml:"metafields,omitempty"`
 	Type            string           `json:"type" yaml:"type,omitempty"`
+	ExternalType    string           `json:"externalType" yaml:"external_type"`
 	UUID            string           `json:"uuid" yaml:"uuid,omitempty"`
 	Version         string           `json:"version" yaml:"version,omitempty"`
 	Surface         string           `json:"surface" yaml:"surface"`
@@ -191,7 +196,7 @@ func (e Extension) UsesNext() bool {
 }
 
 func (e Extension) NormalizedType() string {
-	return strings.Replace(e.Type, "_next", "", -1)
+	return strings.Replace(e.ExternalType, "_next", "", -1)
 }
 
 func (d Development) UsesReact() bool {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -11,6 +11,7 @@ func TestLoadConfig(t *testing.T) {
 	serializedConfig := formatYAML(`---
 extensions:
 	- uuid: 123
+		external_type: checkout_ui
 		type: checkout_ui_extension
 		title: Test Extension
 		name: Alternate Name
@@ -32,6 +33,10 @@ extensions:
 
 	if extension.UUID != "123" {
 		t.Errorf("invalid uuid expected 123 got %s", extension.UUID)
+	}
+
+	if extension.Type != "checkout_ui" {
+		t.Errorf("invalid external extension type – expected checkout_ui got %s", extension.ExternalType)
 	}
 
 	if extension.Type != "checkout_ui_extension" {

--- a/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
+++ b/packages/dev-console-app/src/ExtensionRow/ExtensionRow.tsx
@@ -67,7 +67,7 @@ export function ExtensionRow({
         }
       </td>
       <td className={textClass}>{extension.title}</td>
-      <td className={textClass}>{extension.type}</td>
+      <td className={textClass}>{extension.externalType}</td>
       <td>
         <span className={`${styles.Status} ${statusClass}`}>
           {i18n.translate(`statuses.${status}`)}

--- a/packages/ui-extensions-server-kit/src/testing/extensions.ts
+++ b/packages/ui-extensions-server-kit/src/testing/extensions.ts
@@ -17,6 +17,7 @@ export function mockExtension(obj: DeepPartial<ExtensionPayload> = {}): Extensio
     title: 'My extension',
     surface: 'admin',
     type: 'purchase_option',
+    externalType: 'external_type',
     uuid,
     version: 'extension version',
     ...obj,

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -52,6 +52,7 @@ export interface ResourceURL {
 
 export interface ExtensionPayload {
   type: string;
+  externalType: string;
   assets: {[name: string]: ResourceURL};
   development: {
     hidden: boolean;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/300

### WHAT is this pull request doing?
- Supporting a new configuration attribute for extensions `external_type`
- The value of the new attribute will be used to:
  -  display the type of the extension in the `dev-console` 
  -  fill in the type value in the `.toml` files
- In case the new attribute is not sent (older CLI versions), the already existing `type` attribute will be used instead

### How to test your changes?
- Add the attribute in one of the extension from the `./testdata/extension.config.yml`
- Run the binary with `go run serve . ./testdata/extension.config.yml` 
- Open dev-console in the browser using this url `http://localhost:8000` 
- The extension with the new attribute should show the value add in the type column
