### PR TITLE
Add delve as Homebrew dependency

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -13,3 +13,6 @@ up:
   - node:
       version: v16.13.1
       yarn: v1.22.17
+  - homebrew:
+    - delve
+

--- a/shopify-extensions-debug
+++ b/shopify-extensions-debug
@@ -6,7 +6,7 @@
 
 if ! command -v dlv &> /dev/null; then
     if [ 'Darwin' = $(uname) ] && [ command -v brew ]; then
-        echo "The Delve (Go) debugger is not installed. You can install 'brew install delve'."
+        echo "The Delve (Go) debugger is not installed. Please run `dev up`."
     else
         echo "The Delve (Go) debugger is not installed. Please install it first."
     fi


### PR DESCRIPTION
Follow-up to [this PR](https://github.com/Shopify/shopify-cli-extensions/pull/368), adding suggestions to add `delve` to Homebrew dependencies.