### PR TITLE
Revert "log an error without locales directory"

### DIFF
--- a/build/localization.go
+++ b/build/localization.go
@@ -130,12 +130,7 @@ func reportAndUpdateLocalizationStatus(result Result, report ResultHandler) {
 func WatchLocalization(ctx context.Context, extension core.Extension, report ResultHandler) {
 	directory := filepath.Join(".", extension.Development.RootDir, "locales")
 	if _, err := os.Stat(directory); os.IsNotExist(err) {
-		msg := fmt.Sprintf(
-			"extension must provide a locales directory at: ./%s",
-			directory,
-		)
-		reportAndUpdateLocalizationStatus(Result{false, msg, extension}, report)
-
+		// The extension does not have a locales directory.
 		return
 	}
 


### PR DESCRIPTION
Reverts Shopify/shopify-cli-extensions#364

This introduces an error for extensions not currently using locales:

![image](https://user-images.githubusercontent.com/29458473/181604013-1ff75246-7707-4120-adbf-28cb862af595.png)


We need to find a different approach.