### PR TITLE
Add support for skipping the installation of dependencies

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -172,18 +172,19 @@ type commandConfig struct {
 }
 
 type Development struct {
-	Build              commandConfig     `json:"-" yaml:"build,omitempty"`
-	BuildDir           string            `json:"-" yaml:"build_dir,omitempty"`
-	Develop            commandConfig     `json:"-" yaml:"develop,omitempty"`
-	Entries            map[string]string `json:"-" yaml:"entries,omitempty"`
-	Resource           Url               `json:"resource" yaml:"resource,omitempty"`
-	Renderer           Renderer          `json:"-" yaml:"renderer,omitempty"`
-	Root               Url               `json:"root" yaml:"root,omitempty"`
-	RootDir            string            `json:"-" yaml:"root_dir,omitempty"`
-	Hidden             *bool             `json:"hidden" yaml:"-"`
-	Status             string            `json:"status" yaml:"-"`
-	LocalizationStatus string            `json:"localizationStatus" yaml:"-"`
-	Template           string            `json:"-" yaml:"template,omitempty"`
+	Build               commandConfig     `json:"-" yaml:"build,omitempty"`
+	BuildDir            string            `json:"-" yaml:"build_dir,omitempty"`
+	Develop             commandConfig     `json:"-" yaml:"develop,omitempty"`
+	Entries             map[string]string `json:"-" yaml:"entries,omitempty"`
+	Resource            Url               `json:"resource" yaml:"resource,omitempty"`
+	Renderer            Renderer          `json:"-" yaml:"renderer,omitempty"`
+	Root                Url               `json:"root" yaml:"root,omitempty"`
+	RootDir             string            `json:"-" yaml:"root_dir,omitempty"`
+	Hidden              *bool             `json:"hidden" yaml:"-"`
+	Status              string            `json:"status" yaml:"-"`
+	LocalizationStatus  string            `json:"localizationStatus" yaml:"-"`
+	Template            string            `json:"-" yaml:"template,omitempty"`
+	InstallDependencies *bool             `json:"-" yaml:"install_dependencies,omitempty"`
 }
 
 func (e Extension) UsesNext() bool {

--- a/create/create.go
+++ b/create/create.go
@@ -12,10 +12,17 @@ func ReadTemplateFile(path string) ([]byte, error) {
 }
 
 func NewExtensionProject(extension core.Extension) error {
-	setup := NewProcess(
+	tasks := []Task{
 		MakeDir(extension.Development.RootDir),
 		CreateProject(extension),
-		InstallDependencies(extension.Development.RootDir),
+	}
+
+	if extension.Development.InstallDependencies == nil || *extension.Development.InstallDependencies {
+		tasks = append(tasks, InstallDependencies(extension.Development.RootDir))
+	}
+
+	setup := NewProcess(
+		tasks...,
 	)
 
 	return setup.Run()

--- a/create/create_test.go
+++ b/create/create_test.go
@@ -317,6 +317,42 @@ func TestInstallDependencies(t *testing.T) {
 	})
 }
 
+func TestSkipDependenciesInstallation(t *testing.T) {
+	runnerWasCalled := false
+	Command = func(path, executable string, args ...string) Runner {
+		runnerWasCalled = true
+		return dummyRunner{}
+	}
+	LookPath = func(file string) (string, error) {
+		return file, nil
+	}
+	rootDir := "tmp/TestSkipDependenciesInstallation"
+	installDependencies := false
+	extension := core.Extension{
+		Type: "integration_test",
+		Development: core.Development{
+			InstallDependencies: &installDependencies,
+			Template:            "typescript-react",
+			RootDir:             rootDir,
+			Renderer:            core.Renderer{Name: "@shopify/post-purchase-ui-extension"},
+		},
+	}
+
+	err := NewExtensionProject(extension)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if runnerWasCalled == true {
+		t.Fatal("Expected runner not to be called")
+	}
+
+	t.Cleanup(func() {
+		os.RemoveAll(rootDir)
+	})
+}
+
 func TestCreateLocaleFiles(t *testing.T) {
 	Command = makeDummyRunner
 	LookPath = func(file string) (string, error) {


### PR DESCRIPTION
Related: https://github.com/Shopify/shopify-cli-planning/issues/280

We noticed creating new extensions in a CLI 3.0 project that's using NPM as the package manager yields a `yarn.lock`. After some debugging we realized that the extensions' binary has some logic for installing dependencies. Since this is a responsibility that we've moved to the CLI 3.0, I'm adding an attribute to the configuration schema and using it to skip the installation of dependencies. Please let me know if you'd take a different approach for this one or place the attribute elsewhere in the yaml.