### PR TITLE
Add settings example in checkout ui extension template

### DIFF
--- a/create/templates/projects/checkout_ui_extension/shopify.ui.extension.toml.tpl
+++ b/create/templates/projects/checkout_ui_extension/shopify.ui.extension.toml.tpl
@@ -13,9 +13,6 @@ extension_points = [
 # key = "my-key-2"
 
 # Read more on extension settings at https://shopify.dev/api/checkout-extensions/checkout/settings
-# [settings]
-# type = "$extension:settings"
-
 # [[settings.fields]]
 # key = "heading"
 # name = "Heading"

--- a/create/templates/projects/checkout_ui_extension/shopify.ui.extension.toml.tpl
+++ b/create/templates/projects/checkout_ui_extension/shopify.ui.extension.toml.tpl
@@ -11,3 +11,12 @@ extension_points = [
 # [[metafields]]
 # namespace = "my-namespace"
 # key = "my-key-2"
+
+# Read more on extension settings at https://shopify.dev/api/checkout-extensions/checkout/settings
+# [settings]
+# type = "$extension:settings"
+
+# [[settings.fields]]
+# key = "heading"
+# name = "Heading"
+# type = "single_line_text_field"


### PR DESCRIPTION
## What is this solving ?

Fixes https://github.com/Shopify/checkout-web/issues/12700

Update the checkout extension template to display an example of extension settings.

## Note

* I've added a link to where the new extension settings docs will live, per https://github.com/Shopify/shopify-dev/pull/23127