### PR TITLE
adding blockProgress capability for checkout ui extensions

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -806,7 +806,8 @@ func TestWebsocketClientDispatchEventWithoutMutatingData(t *testing.T) {
 			"localization": null,
 			"surface": "checkout",
 			"capabilities": {
-				"networkAccess": false
+				"networkAccess": false,
+				"blockProgress": false
 			}
 		}
 		]`, extensionAssetUrl, extensionRootUrl, dispatchExtensionUUID)

--- a/core/core.go
+++ b/core/core.go
@@ -83,6 +83,10 @@ func normalizeConfig(config *Config) {
 			config.Extensions[index].Capabilities.NetworkAccess = NewBoolPointer(false)
 		}
 
+		if config.Extensions[index].Capabilities.BlockProgress == nil {
+			config.Extensions[index].Capabilities.BlockProgress = NewBoolPointer(false)
+		}
+
 		if config.Extensions[index].Development.Hidden == nil {
 			config.Extensions[index].Development.Hidden = NewBoolPointer(false)
 		}
@@ -133,6 +137,7 @@ type Localization struct {
 
 type Capabilities struct {
 	NetworkAccess *bool `json:"networkAccess" yaml:"network_access"`
+	BlockProgress *bool `json:"blockProgress" yaml:"block_progress"`
 }
 
 type Extension struct {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -17,6 +17,7 @@ extensions:
 		name: Alternate Name
 		capabilities:
 			network_access: true
+			block_progress: true
 `)
 
 	config, err := core.LoadConfig(strings.NewReader(serializedConfig))
@@ -53,6 +54,10 @@ extensions:
 
 	if *extension.Capabilities.NetworkAccess != true {
 		t.Errorf("invalid value for Capabilities - expected network_access got %t", *extension.Capabilities.NetworkAccess)
+	}
+
+	if *extension.Capabilities.BlockProgress != true {
+		t.Errorf("invalid value for Capabilities - expected block_progress got %t", *extension.Capabilities.BlockProgress)
 	}
 }
 


### PR DESCRIPTION
resolves https://github.com/Shopify/checkout-web/issues/12795

we've added a new `block_progress` flag to our checkout ui extension configuration